### PR TITLE
doc: fix scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a Model Context Protocol (MCP) server implementation for Xero. It provid
 Set up a Custom Connection following these instructions: https://developer.xero.com/documentation/guides/oauth2/custom-connections/
 
 Currently the following scopes are required:
-`accounting.transactions accounting.contacts accounting.settings.read`
+`accounting.transactions accounting.contacts accounting.settings.read accounting.reports.read`
 
 ### Integrating the MCP server with Claude Desktop
 


### PR DESCRIPTION
Update docs to use the correct scopes to avoid the following error in Claude Desktop:
```
Error listing invoices: Failed to get Xero token: [object Object]
```

by aligning with the codebase [here](https://github.com/tekumara/xero-mcp-server/blob/8eae3eed7879f01c369d4ddfc72ed9fc1b100fa4/src/clients/xero-client.ts#L92). 
