### PR TITLE
feat: add list payroll employees tool/handler (nz/uk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a Model Context Protocol (MCP) server implementation for Xero. It provid
 Set up a Custom Connection following these instructions: https://developer.xero.com/documentation/guides/oauth2/custom-connections/
 
 Currently the following scopes are required:
-`accounting.transactions accounting.contacts accounting.settings.read accounting.reports.read`
+`accounting.transactions accounting.contacts accounting.settings.read accounting.reports.read payroll.employees.read`
 
 ### Integrating the MCP server with Claude Desktop
 

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -89,7 +89,7 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
 
   public async getClientCredentialsToken(): Promise<TokenSet> {
     const scope =
-      "accounting.transactions accounting.contacts accounting.settings.read accounting.reports.read";
+      "accounting.transactions accounting.contacts accounting.settings.read accounting.reports.read payroll.employees.read";
     const credentials = Buffer.from(
       `${this.clientId}:${this.clientSecret}`,
     ).toString("base64");

--- a/src/handlers/list-xero-payroll-employees.handler.ts
+++ b/src/handlers/list-xero-payroll-employees.handler.ts
@@ -1,0 +1,42 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { Employee } from "xero-node";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+async function getPayrollEmployees(): Promise<Employee[]> {
+  await xeroClient.authenticate();
+
+  // Call the Employees endpoint from the PayrollNZApi
+  const employees = await xeroClient.payrollNZApi.getEmployees(
+    xeroClient.tenantId,
+    undefined, // page
+    undefined, // pageSize
+    getClientHeaders(),
+  );
+
+  return employees.body.employees ?? [];
+}
+
+/**
+ * List all payroll employees from Xero
+ */
+export async function listXeroPayrollEmployees(): Promise<
+  XeroClientResponse<Employee[]>
+> {
+  try {
+    const employees = await getPayrollEmployees();
+
+    return {
+      result: employees,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -7,6 +7,7 @@ import ListQuotesTool from "./list-quotes.tool.js";
 import ListTaxRatesTool from "./list-tax-rates.tool.js";
 import ListTrialBalanceTool from "./list-trial-balance.tool.js";
 import ListProfitAndLossTool from "./list-profit-and-loss.tool.js";
+import ListPayrollEmployeesTool from "./list-payroll-employees.tool.js";
 
 export const ListTools = [
   ListAccountsTool,
@@ -18,4 +19,5 @@ export const ListTools = [
   ListTaxRatesTool,
   ListTrialBalanceTool,
   ListProfitAndLossTool,
+  ListPayrollEmployeesTool
 ];

--- a/src/tools/list/list-payroll-employees.tool.ts
+++ b/src/tools/list/list-payroll-employees.tool.ts
@@ -1,0 +1,55 @@
+import { Employee } from "xero-node/dist/gen/model/payroll-nz/employee.js"
+import { listXeroPayrollEmployees } from "../../handlers/list-xero-payroll-employees.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const ListPayrollEmployeesTool = CreateXeroTool(
+  "list-payroll-employees",
+  `List all payroll employees in Xero.
+This retrieves comprehensive employee details including names, User IDs, dates of birth, email addresses, gender, phone numbers, start dates, engagement types (Permanent, FixedTerm, or Casual), titles, and when records were last updated.
+The response presents a complete overview of all staff currently registered in your Xero payroll, with their personal and employment information. If there are many employees, ask the user if they would like to see more detailed information about specific employees before proceeding.`,
+  {},
+  async () => {
+    const response = await listXeroPayrollEmployees();
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing payroll employees: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const employees = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${employees?.length || 0} payroll employees:`,
+        },
+        ...(employees?.map((employee: Employee) => ({
+          type: "text" as const,
+          text: [
+            `Employee: ${employee.employeeID}`,
+            employee.email ? `Email: ${employee.email}` : "No email",
+            employee.gender ? `Gender: ${employee.gender}` : null,
+            employee.phoneNumber ? `Phone: ${employee.phoneNumber}` : null,
+            employee.startDate ? `Start Date: ${employee.startDate}` : null,
+            employee.engagementType ? `Engagement Type: ${employee.engagementType}` : "No status", // Permanent, FixedTerm, Casual
+            employee.title ? `Title: ${employee.title}` : null,
+            employee.firstName ? `First Name: ${employee.firstName}` : null,
+            employee.lastName ? `Last Name: ${employee.lastName}` : null,
+            employee.updatedDateUTC ? `Last Updated: ${employee.updatedDateUTC}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPayrollEmployeesTool;


### PR DESCRIPTION
Allows users to query for payroll employees (nz/uk api) and their info.

Also did some refactoring to the xero-client to allow flexability with scopes for different kinds of handlers.
I have tested positive/negative scenarios with claude locally with changes to the client scopes in the xero developer platform.