### PR TITLE
Add glama.json to verify server on glama.ai

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://glama.ai/mcp/schemas/server.json",
+    "maintainers": [
+      "TheRegan",
+      "Stanislav-Pankrashin"
+    ]
+  }


### PR DESCRIPTION
We're getting some traffic from https://glama.ai/mcp/servers/@XeroAPI/xero-mcp-server and we need to add this json file to verify the server there so we can improve our listing