### PR TITLE
feat: implement list payroll employee leave tools (nz/uk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ NOTE: The `XERO_CLIENT_BEARER_TOKEN` will take precedence over the `XERO_CLIENT_
 - `list-items`: Retrieve a list of items
 - `list-bank-transactions`: Retrieve a list of bank account transactions
 - `list-payroll-employees`: Retrieve a list of Payroll Employees
+- `list-payroll-employee-leave`: Retrieve a Payroll Employee's leave records
+- `list-payroll-employee-leave-balances`: Retrieve a Payroll Employee's leave balances
+- `list-payroll-employee-leave-types`: Retrieve a list of Payroll leave types
+- `list-payroll-leave-periods`: Retrieve a list of a Payroll Employee's leave periods
+- `list-payroll-leave-types`: Retrieve a list of all avaliable leave types in Xero Payroll
 - `create-contact`: Create a new contact
 - `create-invoice`: Create a new invoice
 - `create-quote`: Create a new quote

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -89,7 +89,7 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
 
   public async getClientCredentialsToken(): Promise<TokenSet> {
     const scope =
-      "accounting.transactions accounting.contacts accounting.settings accounting.reports.read payroll.employees.read";
+      "accounting.transactions accounting.contacts accounting.settings accounting.reports.read payroll.employees.read payroll.settings.read";
     const credentials = Buffer.from(
       `${this.clientId}:${this.clientSecret}`,
     ).toString("base64");

--- a/src/handlers/list-xero-payroll-employee-leave-balances.handler.ts
+++ b/src/handlers/list-xero-payroll-employee-leave-balances.handler.ts
@@ -1,0 +1,56 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { EmployeeLeaveBalance } from "xero-node/dist/gen/model/payroll-nz/employeeLeaveBalance.js";
+
+/**
+ * Internal function to fetch employee leave balances from Xero
+ */
+async function fetchEmployeeLeaveBalances(employeeId: string): Promise<EmployeeLeaveBalance[] | null> {
+  await xeroClient.authenticate();
+
+  if (!employeeId) {
+    throw new Error("Employee ID is required to fetch employee leave balances");
+  }
+
+  const response = await xeroClient.payrollNZApi.getEmployeeLeaveBalances(
+    xeroClient.tenantId,
+    employeeId,
+    getClientHeaders(),
+  );
+
+  return response.body.leaveBalances ?? null;
+}
+
+/**
+ * List employee leave balances from Xero Payroll
+ * @param employeeId The ID of the employee to retrieve leave balances for
+ */
+export async function listXeroPayrollEmployeeLeaveBalances(
+  employeeId: string,
+): Promise<XeroClientResponse<EmployeeLeaveBalance[]>> {
+  try {
+    const leaveBalances = await fetchEmployeeLeaveBalances(employeeId);
+
+    if (!leaveBalances) {
+      return {
+        result: [],
+        isError: false,
+        error: null,
+      };
+    }
+
+    return {
+      result: leaveBalances,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-payroll-employee-leave-types.handler.ts
+++ b/src/handlers/list-xero-payroll-employee-leave-types.handler.ts
@@ -1,0 +1,56 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { EmployeeLeaveType } from "xero-node/dist/gen/model/payroll-nz/employeeLeaveType.js";
+
+/**
+ * Internal function to fetch employee leave types from Xero
+ */
+async function fetchEmployeeLeaveTypes(employeeId: string): Promise<EmployeeLeaveType[] | null> {
+  await xeroClient.authenticate();
+
+  if (!employeeId) {
+    throw new Error("Employee ID is required to fetch employee leave types");
+  }
+
+  const response = await xeroClient.payrollNZApi.getEmployeeLeaveTypes(
+    xeroClient.tenantId,
+    employeeId,
+    getClientHeaders(),
+  );
+
+  return response.body.leaveTypes ?? null;
+}
+
+/**
+ * List employee leave types from Xero Payroll
+ * @param employeeId The ID of the employee to retrieve leave types for
+ */
+export async function listXeroPayrollEmployeeLeaveTypes(
+  employeeId: string,
+): Promise<XeroClientResponse<EmployeeLeaveType[]>> {
+  try {
+    const leaveTypes = await fetchEmployeeLeaveTypes(employeeId);
+
+    if (!leaveTypes) {
+      return {
+        result: [],
+        isError: false,
+        error: null,
+      };
+    }
+
+    return {
+      result: leaveTypes,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-payroll-employee-leave.handler.ts
+++ b/src/handlers/list-xero-payroll-employee-leave.handler.ts
@@ -1,0 +1,63 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+// Import the correct types - using the proper namespace
+import { EmployeeLeave } from "xero-node/dist/gen/model/payroll-nz/employeeLeave.js";
+
+interface FetchEmployeeLeaveParams {
+  employeeId?: string;
+}
+
+/**
+ * Internal function to fetch employee leave from Xero
+ */
+async function fetchEmployeeLeave({ employeeId }: FetchEmployeeLeaveParams): Promise<EmployeeLeave[] | null> {
+  await xeroClient.authenticate();
+
+  if (!employeeId) {
+    throw new Error("Employee ID is required to fetch employee leave");
+  }
+
+  const response = await xeroClient.payrollNZApi.getEmployeeLeaves(
+    xeroClient.tenantId,
+    employeeId,
+    {
+      headers: getClientHeaders().headers
+    }
+  );
+
+  return response.body.leave ?? null;
+}
+
+/**
+ * List employee leave from Xero Payroll
+ * @param employeeId The ID of the employee to retrieve leave for
+ */
+export async function listXeroPayrollEmployeeLeave(
+  employeeId: string,
+): Promise<XeroClientResponse<EmployeeLeave[]>> {
+  try {
+    const leave = await fetchEmployeeLeave({ employeeId });
+
+    if (!leave) {
+      return {
+        result: [],
+        isError: false,
+        error: null,
+      };
+    }
+
+    return {
+      result: leave,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-payroll-leave-periods.handler.ts
+++ b/src/handlers/list-xero-payroll-leave-periods.handler.ts
@@ -1,0 +1,70 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { LeavePeriod } from "xero-node/dist/gen/model/payroll-nz/leavePeriod.js";
+
+interface FetchLeavePeriodParams {
+  employeeId?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+/**
+ * Internal function to fetch employee leave periods from Xero
+ */
+async function fetchLeavePeriods({
+  employeeId,
+  startDate,
+  endDate,
+}: FetchLeavePeriodParams): Promise<LeavePeriod[] | null> {
+  await xeroClient.authenticate();
+
+  if (!employeeId) {
+    throw new Error("Employee ID is required to fetch leave periods");
+  }  // After reviewing the SDK documentation, it appears this API call requires different parameters
+  // Use parameters that match the SDK's expectations
+  const response = await xeroClient.payrollNZApi.getEmployeeLeavePeriods(
+    xeroClient.tenantId,
+    employeeId,
+    startDate,
+    endDate,
+  );
+
+  return response.body.periods ?? null;
+}
+
+/**
+ * List employee leave periods from Xero Payroll
+ * @param employeeId The ID of the employee to retrieve leave periods for
+ * @param startDate Optional start date in YYYY-MM-DD format
+ * @param endDate Optional end date in YYYY-MM-DD format
+ */
+export async function listXeroPayrollLeavePeriods(
+  employeeId: string,
+  startDate?: string,
+  endDate?: string,
+): Promise<XeroClientResponse<LeavePeriod[]>> {
+  try {
+    const periods = await fetchLeavePeriods({ employeeId, startDate, endDate });
+
+    if (!periods) {
+      return {
+        result: [],
+        isError: false,
+        error: null,
+      };
+    }
+
+    return {
+      result: periods,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-payroll-leave-types.handler.ts
+++ b/src/handlers/list-xero-payroll-leave-types.handler.ts
@@ -1,0 +1,52 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { LeaveType } from "xero-node/dist/gen/model/payroll-nz/leaveType.js";
+
+/**
+ * Internal function to fetch leave types from Xero
+ */
+async function fetchLeaveTypes(): Promise<LeaveType[] | null> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.payrollNZApi.getLeaveTypes(
+    xeroClient.tenantId,
+    undefined, // page
+    undefined, // pageSize
+    getClientHeaders(),
+  );
+
+  return response.body.leaveTypes ?? null;
+}
+
+/**
+ * List all leave types from Xero Payroll
+ */
+export async function listXeroPayrollLeaveTypes(): Promise<
+  XeroClientResponse<LeaveType[]>
+> {
+  try {
+    const leaveTypes = await fetchLeaveTypes();
+
+    if (!leaveTypes) {
+      return {
+        result: [],
+        isError: false,
+        error: null,
+      };
+    }
+
+    return {
+      result: leaveTypes,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -9,6 +9,11 @@ import ListTrialBalanceTool from "./list-trial-balance.tool.js";
 import ListProfitAndLossTool from "./list-profit-and-loss.tool.js";
 import ListPayrollEmployeesTool from "./list-payroll-employees.tool.js";
 import ListBankTransactionsTool from "./list-bank-transactions.tool.js";
+import ListPayrollEmployeeLeaveTool from "./list-payroll-employee-leave.tool.js";
+import ListPayrollLeavePeriodsToolTool from "./list-payroll-leave-periods.tool.js";
+import ListPayrollEmployeeLeaveTypesTool from "./list-payroll-employee-leave-types.tool.js";
+import ListPayrollEmployeeLeaveBalancesTool from "./list-payroll-employee-leave-balances.tool.js";
+import ListPayrollLeaveTypesTool from "./list-payroll-leave-types.tool.js";
 
 export const ListTools = [
   ListAccountsTool,
@@ -22,4 +27,9 @@ export const ListTools = [
   ListProfitAndLossTool,
   ListPayrollEmployeesTool,
   ListBankTransactionsTool,
+  ListPayrollEmployeeLeaveTool,
+  ListPayrollLeavePeriodsToolTool,
+  ListPayrollEmployeeLeaveTypesTool,
+  ListPayrollEmployeeLeaveBalancesTool,
+  ListPayrollLeaveTypesTool
 ];

--- a/src/tools/list/list-payroll-employee-leave-balances.tool.ts
+++ b/src/tools/list/list-payroll-employee-leave-balances.tool.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import { listXeroPayrollEmployeeLeaveBalances } from "../../handlers/list-xero-payroll-employee-leave-balances.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { EmployeeLeaveBalance } from "xero-node/dist/gen/model/payroll-nz/employeeLeaveBalance.js";
+
+const ListPayrollEmployeeLeaveBalancesTool = CreateXeroTool(
+  "list-payroll-employee-leave-balances",
+  "List all leave balances for a specific employee in Xero. This shows current leave balances for all leave types available to the employee, including annual, sick, and other leave types.",
+  {
+    employeeId: z.string().describe("The Xero employee ID to fetch leave balances for"),
+  },
+  async ({ employeeId }) => {
+    const response = await listXeroPayrollEmployeeLeaveBalances(employeeId);
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing employee leave balances: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const leaveBalances = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${leaveBalances?.length || 0} leave balances for employee ${employeeId}:`,
+        },
+        ...(leaveBalances?.map((balance: EmployeeLeaveBalance) => ({
+          type: "text" as const,
+          text: [
+            `Leave Type ID: ${balance.leaveTypeID || "Unknown"}`,
+            `Name: ${balance.name || "Unnamed"}`,
+            balance.typeOfUnits ? `Type Of Units: ${balance.typeOfUnits}` : null,
+            balance.balance !== undefined ? `Current Balance: ${balance.balance}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPayrollEmployeeLeaveBalancesTool;

--- a/src/tools/list/list-payroll-employee-leave-types.tool.ts
+++ b/src/tools/list/list-payroll-employee-leave-types.tool.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { listXeroPayrollEmployeeLeaveTypes } from "../../handlers/list-xero-payroll-employee-leave-types.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { EmployeeLeaveType } from "xero-node/dist/gen/model/payroll-nz/employeeLeaveType.js";
+
+const ListPayrollEmployeeLeaveTypesTool = CreateXeroTool(
+  "list-payroll-employee-leave-types",
+  "List all leave types available for a specific employee in Xero. This shows detailed information about the types of leave an employee can take, including schedule of accrual, leave type name, and entitlement.",
+  {
+    employeeId: z
+      .string()
+      .describe("The Xero employee ID to fetch leave types for"),
+  },
+  async ({ employeeId }) => {
+    const response = await listXeroPayrollEmployeeLeaveTypes(employeeId);
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing employee leave types: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const leaveTypes = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${leaveTypes?.length || 0} leave types for employee ${employeeId}:`,
+        },
+        ...(leaveTypes?.map((leaveType: EmployeeLeaveType) => ({
+          type: "text" as const,
+          text: [
+            `Leave Type ID: ${leaveType.leaveTypeID || "Unknown"}`,
+            `Schedule of Accrual: ${leaveType.scheduleOfAccrual || "Unknown"}`,
+            leaveType.hoursAccruedAnnually
+              ? `Hours Accrued Annually: ${leaveType.hoursAccruedAnnually}`
+              : null,
+            leaveType.maximumToAccrue
+              ? `Maximum To Accrue: ${leaveType.maximumToAccrue}`
+              : null,
+            leaveType.openingBalance
+              ? `Opening Balance: ${leaveType.openingBalance}`
+              : null,
+            leaveType.rateAccruedHourly
+              ? `Rate Accrued Hourly: ${leaveType.rateAccruedHourly}`
+              : null,
+            leaveType.leaveTypeID
+              ? `Leave Type ID: ${leaveType.leaveTypeID}`
+              : null,
+            leaveType.scheduleOfAccrualDate
+              ? `Accrual Date: ${leaveType.scheduleOfAccrualDate}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPayrollEmployeeLeaveTypesTool;

--- a/src/tools/list/list-payroll-employee-leave.tool.ts
+++ b/src/tools/list/list-payroll-employee-leave.tool.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { listXeroPayrollEmployeeLeave } from "../../handlers/list-xero-payroll-employee-leave.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { EmployeeLeave } from "xero-node/dist/gen/model/payroll-nz/employeeLeave.js";
+
+const ListPayrollEmployeeLeaveTool = CreateXeroTool(
+  "list-payroll-employee-leave",
+  "List all leave records for a specific employee in Xero. This shows all leave transactions including approved, pending, and processed time off. Provide an employee ID to see their leave history.",
+  {
+    employeeId: z.string().describe("The Xero employee ID to fetch leave records for"),
+  },
+  async ({ employeeId }) => {
+    const response = await listXeroPayrollEmployeeLeave(employeeId);
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing employee leave: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const leave = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${leave?.length || 0} leave records for employee ${employeeId}:`,
+        },
+        ...(leave?.map((leaveItem: EmployeeLeave) => ({
+          type: "text" as const,
+          text: [
+            `Leave ID: ${leaveItem.leaveID || "Unknown"}`,
+            `Leave Type: ${leaveItem.leaveTypeID || "Unknown"}`,
+            `Description: ${leaveItem.description || "No description"}`,
+            leaveItem.startDate ? `Start Date: ${leaveItem.startDate}` : null,
+            leaveItem.endDate ? `End Date: ${leaveItem.endDate}` : null,
+            leaveItem.periods ? `Periods: ${leaveItem.periods.length || 0}` : null,
+            leaveItem.updatedDateUTC ? `Last Updated: ${leaveItem.updatedDateUTC}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPayrollEmployeeLeaveTool;

--- a/src/tools/list/list-payroll-leave-periods.tool.ts
+++ b/src/tools/list/list-payroll-leave-periods.tool.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import { listXeroPayrollLeavePeriods } from "../../handlers/list-xero-payroll-leave-periods.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { LeavePeriod } from "xero-node/dist/gen/model/payroll-nz/leavePeriod.js";
+
+const ListPayrollLeavePeriodsToolTool = CreateXeroTool(
+  "list-payroll-leave-periods",
+  "List all leave periods for a specific employee in Xero. This shows detailed time off periods including start and end dates, period status, payment dates, and leave types. Provide an employee ID to see their leave periods.",
+  {
+    employeeId: z.string().describe("The Xero employee ID to fetch leave periods for"),
+    startDate: z.string().optional().describe("Optional start date in YYYY-MM-DD format"),
+    endDate: z.string().optional().describe("Optional end date in YYYY-MM-DD format"),
+  },
+  async ({ employeeId, startDate, endDate }) => {
+    const response = await listXeroPayrollLeavePeriods(employeeId, startDate, endDate);
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing employee leave periods: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const periods = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${periods?.length || 0} leave periods for employee ${employeeId}:`,
+        },
+        ...(periods?.map((period: LeavePeriod) => ({
+          type: "text" as const,
+          text: [
+            `Period Status: ${period.periodStatus || "Unknown"}`,
+            period.periodStartDate ? `Start Date: ${period.periodStartDate}` : null,
+            period.periodEndDate ? `End Date: ${period.periodEndDate}` : null,
+            period.numberOfUnits ? `Number of Units: ${period.numberOfUnits}` : null,
+            period.numberOfUnitsTaken ? `Payment Date: ${period.numberOfUnitsTaken}` : null,
+            period.typeOfUnits ? `Payment Date: ${period.typeOfUnits}` : null,
+            period.typeOfUnitsTaken ? `Payment Date: ${period.typeOfUnitsTaken}` : null,
+            period.periodStatus ? `Period Status: ${period.periodStatus}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPayrollLeavePeriodsToolTool;

--- a/src/tools/list/list-payroll-leave-types.tool.ts
+++ b/src/tools/list/list-payroll-leave-types.tool.ts
@@ -1,0 +1,49 @@
+import { listXeroPayrollLeaveTypes } from "../../handlers/list-xero-payroll-leave-types.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { LeaveType } from "xero-node/dist/gen/model/payroll-nz/leaveType.js";
+
+const ListPayrollLeaveTypesTool = CreateXeroTool(
+  "list-payroll-leave-types",
+  "Lists all available leave types in Xero Payroll. This provides information about all the leave categories configured in your Xero system, including statutory and organization-specific leave types.",
+  {},
+  async () => {
+    const response = await listXeroPayrollLeaveTypes();
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing payroll leave types: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const leaveTypes = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${leaveTypes?.length || 0} payroll leave types:`,
+        },        ...(leaveTypes?.map((leaveType: LeaveType) => ({
+          type: "text" as const,
+          text: [
+            `Leave Type: ${leaveType.name || "Unnamed"}`,
+            `Leave Type ID: ${leaveType.leaveTypeID || "Unknown"}`,
+            leaveType.isPaidLeave !== undefined ? `Is Paid Leave: ${leaveType.isPaidLeave ? 'Yes' : 'No'}` : null,
+            leaveType.showOnPayslip !== undefined ? `Show On Payslip: ${leaveType.showOnPayslip ? 'Yes' : 'No'}` : null,
+            leaveType.isActive !== undefined ? `Is Active: ${leaveType.isActive ? 'Yes' : 'No'}` : null,
+            leaveType.typeOfUnits ? `Type Of Units: ${leaveType.typeOfUnits}` : null,
+            leaveType.typeOfUnitsToAccrue ? `Type Of Units To Accrue: ${leaveType.typeOfUnitsToAccrue}` : null,
+            leaveType.updatedDateUTC ? `Last Updated: ${leaveType.updatedDateUTC}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPayrollLeaveTypesTool;


### PR DESCRIPTION
Added GET endpoints for the following:
- `list-payroll-employee-leave`: Retrieve a Payroll Employee's leave records
- `list-payroll-employee-leave-balances`: Retrieve a Payroll Employee's leave balances
- `list-payroll-employee-leave-types`: Retrieve a list of Payroll leave types
- `list-payroll-leave-periods`: Retrieve a list of a Payroll Employee's leave periods
- `list-payroll-leave-types`: Retrieve a list of all avaliable leave types in Xero Payroll