### PR TITLE
fix: add missing tools and handlers for timesheets

### DIFF
--- a/src/handlers/approve-xero-payroll-timesheet.handler.ts
+++ b/src/handlers/approve-xero-payroll-timesheet.handler.ts
@@ -1,0 +1,40 @@
+import { Timesheet } from "xero-node/dist/gen/model/payroll-nz/timesheet.js";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function approveTimesheet(timesheetID: string): Promise<Timesheet | null> {
+  await xeroClient.authenticate();
+
+  // Call the approveTimesheet endpoint from the PayrollNZApi
+  const approvedTimesheet = await xeroClient.payrollNZApi.approveTimesheet(
+    xeroClient.tenantId,
+    timesheetID,
+  );
+
+  return approvedTimesheet.body.timesheet ?? null;
+}
+
+/**
+ * Approve a payroll timesheet in Xero
+ */
+export async function approveXeroPayrollTimesheet(timesheetID: string): Promise<
+  XeroClientResponse<Timesheet | null>
+> {
+  try {
+    const approvedTimesheet = await approveTimesheet(timesheetID);
+
+    return {
+      result: approvedTimesheet,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/create-xero-payroll-timesheet.handler.ts
+++ b/src/handlers/create-xero-payroll-timesheet.handler.ts
@@ -1,0 +1,40 @@
+import { Timesheet } from "xero-node/dist/gen/model/payroll-nz/timesheet.js";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function createTimesheet(timesheet: Timesheet): Promise<Timesheet | null> {
+  await xeroClient.authenticate();
+
+  // Call the createTimesheet endpoint from the PayrollNZApi
+  const createdTimesheet = await xeroClient.payrollNZApi.createTimesheet(
+    xeroClient.tenantId,
+    timesheet,
+  );
+
+  return createdTimesheet.body.timesheet ?? null;
+}
+
+/**
+ * Create a payroll timesheet in Xero
+ */
+export async function createXeroPayrollTimesheet(timesheet: Timesheet): Promise<
+  XeroClientResponse<Timesheet | null>
+> {
+  try {
+    const newTimesheet = await createTimesheet(timesheet);
+
+    return {
+      result: newTimesheet,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/delete-xero-payroll-timesheet.handler.ts
+++ b/src/handlers/delete-xero-payroll-timesheet.handler.ts
@@ -1,0 +1,35 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function deleteTimesheet(timesheetID: string): Promise<boolean> {
+  await xeroClient.authenticate();
+
+  // Call the deleteTimesheet endpoint from the PayrollNZApi
+  await xeroClient.payrollNZApi.deleteTimesheet(xeroClient.tenantId, timesheetID);
+
+  return true;
+}
+
+/**
+ * Delete an existing payroll timesheet in Xero
+ */
+export async function deleteXeroPayrollTimesheet(timesheetID: string): Promise<
+  XeroClientResponse<boolean>
+> {
+  try {
+    await deleteTimesheet(timesheetID);
+
+    return {
+      result: true,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/get-xero-payroll-timesheet.handler.ts
+++ b/src/handlers/get-xero-payroll-timesheet.handler.ts
@@ -1,0 +1,40 @@
+import { Timesheet } from "xero-node/dist/gen/model/payroll-nz/timesheet.js";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function getTimesheet(timesheetID: string): Promise<Timesheet | null> {
+  await xeroClient.authenticate();
+
+  // Call the Timesheet endpoint from the PayrollNZApi
+  const timesheet = await xeroClient.payrollNZApi.getTimesheet(
+    xeroClient.tenantId,
+    timesheetID,
+  );
+
+  return timesheet.body.timesheet ?? null;
+}
+
+/**
+ * Get a single payroll timesheet from Xero
+ */
+export async function getXeroPayrollTimesheet(timesheetID: string): Promise<
+  XeroClientResponse<Timesheet | null>
+> {
+  try {
+    const timesheet = await getTimesheet(timesheetID);
+
+    return {
+      result: timesheet,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/revert-xero-payroll-timesheet.handler.ts
+++ b/src/handlers/revert-xero-payroll-timesheet.handler.ts
@@ -1,0 +1,40 @@
+import { Timesheet } from "xero-node/dist/gen/model/payroll-nz/timesheet.js";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function revertTimesheet(timesheetID: string): Promise<Timesheet | null> {
+  await xeroClient.authenticate();
+
+  // Call the revertTimesheet endpoint from the PayrollNZApi
+  const revertedTimesheet = await xeroClient.payrollNZApi.revertTimesheet(
+    xeroClient.tenantId,
+    timesheetID,
+  );
+
+  return revertedTimesheet.body.timesheet ?? null;
+}
+
+/**
+ * Revert a payroll timesheet to draft in Xero
+ */
+export async function revertXeroPayrollTimesheet(timesheetID: string): Promise<
+  XeroClientResponse<Timesheet | null>
+> {
+  try {
+    const revertedTimesheet = await revertTimesheet(timesheetID);
+
+    return {
+      result: revertedTimesheet,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/update-xero-payroll-timesheet-add-line.handler.ts
+++ b/src/handlers/update-xero-payroll-timesheet-add-line.handler.ts
@@ -1,0 +1,43 @@
+import {
+  TimesheetLine,
+} from "xero-node/dist/gen/model/payroll-nz/timesheetLine.js";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function addTimesheetLine(timesheetID: string, timesheetLine: TimesheetLine): Promise<TimesheetLine | null> {
+  await xeroClient.authenticate();
+
+  // Call the createTimesheetLine endpoint from the PayrollNZApi
+  const createdLine = await xeroClient.payrollNZApi.createTimesheetLine(
+    xeroClient.tenantId,
+    timesheetID,
+    timesheetLine,
+  );
+
+  return createdLine.body.timesheetLine ?? null;
+}
+
+/**
+ * Add a timesheet line to an existing payroll timesheet in Xero
+ */
+export async function updateXeroPayrollTimesheetAddLine(timesheetID: string, timesheetLine: TimesheetLine): Promise<
+  XeroClientResponse<TimesheetLine | null>
+> {
+  try {
+    const newLine = await addTimesheetLine(timesheetID, timesheetLine);
+
+    return {
+      result: newLine,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/update-xero-payroll-timesheet-update-line.handler.ts
+++ b/src/handlers/update-xero-payroll-timesheet-update-line.handler.ts
@@ -1,0 +1,50 @@
+import {
+  TimesheetLine,
+} from "xero-node/dist/gen/model/payroll-nz/timesheetLine.js";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function updateTimesheetLine(
+  timesheetID: string,
+  timesheetLineID: string,
+  timesheetLine: TimesheetLine
+): Promise<TimesheetLine | null> {
+  await xeroClient.authenticate();
+
+  // Call the updateTimesheetLine endpoint from the PayrollNZApi
+  const updatedLine = await xeroClient.payrollNZApi.updateTimesheetLine(
+    xeroClient.tenantId,
+    timesheetID,
+    timesheetLineID,
+    timesheetLine,
+  );
+
+  return updatedLine.body.timesheetLine ?? null;
+}
+
+/**
+ * Update an existing timesheet line in a payroll timesheet in Xero
+ */
+export async function updateXeroPayrollTimesheetUpdateLine(
+  timesheetID: string,
+  timesheetLineID: string,
+  timesheetLine: TimesheetLine
+): Promise<XeroClientResponse<TimesheetLine | null>> {
+  try {
+    const updatedLine = await updateTimesheetLine(timesheetID, timesheetLineID, timesheetLine);
+
+    return {
+      result: updatedLine,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/tools/create/create-payroll-timesheet.tool.ts
+++ b/src/tools/create/create-payroll-timesheet.tool.ts
@@ -1,0 +1,56 @@
+import { Timesheet } from "xero-node/dist/gen/model/payroll-nz/timesheet.js";
+import { z } from "zod";
+
+import {
+  createXeroPayrollTimesheet,
+} from "../../handlers/create-xero-payroll-timesheet.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const CreatePayrollTimesheetTool = CreateXeroTool(
+  "create-timesheet",
+  `Create a new payroll timesheet in Xero.
+This allows you to specify details such as the employee ID, payroll calendar ID, start and end dates, and timesheet lines.`,
+  {
+    payrollCalendarID: z.string().describe("The ID of the payroll calendar."),
+    employeeID: z.string().describe("The ID of the employee."),
+    startDate: z.string().describe("The start date of the timesheet period (YYYY-MM-DD)."),
+    endDate: z.string().describe("The end date of the timesheet period (YYYY-MM-DD)."),
+    timesheetLines: z
+      .array(
+        z.object({
+          earningsRateID: z.string().describe("The ID of the earnings rate."),
+          numberOfUnits: z.number().describe("The number of units for the timesheet line."),
+          date: z.string().describe("The date for the timesheet line (YYYY-MM-DD)."),
+        })
+      )
+      .optional()
+      .describe("The lines of the timesheet."),
+  },
+  async (params: Timesheet) => {
+    const response = await createXeroPayrollTimesheet(params);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error creating timesheet: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const timesheet = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Successfully created timesheet with ID: ${timesheet?.timesheetID}`,
+        },
+      ],
+    };
+  },
+);
+
+export default CreatePayrollTimesheetTool;

--- a/src/tools/delete/delete-payroll-timesheet.tool.ts
+++ b/src/tools/delete/delete-payroll-timesheet.tool.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+import {
+  deleteXeroPayrollTimesheet,
+} from "../../handlers/delete-xero-payroll-timesheet.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const DeletePayrollTimesheetTool = CreateXeroTool(
+  "delete-timesheet",
+  `Delete an existing payroll timesheet in Xero by its ID.`,
+  {
+    timesheetID: z.string().describe("The ID of the timesheet to delete."),
+  },
+  async (params: { timesheetID: string }) => {
+    const { timesheetID } = params;
+    const response = await deleteXeroPayrollTimesheet(timesheetID);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error deleting timesheet: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Successfully deleted timesheet with ID: ${timesheetID}`,
+        },
+      ],
+    };
+  },
+);
+
+export default DeletePayrollTimesheetTool;

--- a/src/tools/get/get-payroll-timesheet.tool.ts
+++ b/src/tools/get/get-payroll-timesheet.tool.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+import {
+  getXeroPayrollTimesheet,
+} from "../../handlers/get-xero-payroll-timesheet.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const GetPayrollTimesheetTool = CreateXeroTool(
+  "get-timesheet",
+  `Retrieve a single payroll timesheet from Xero by its ID.
+This provides details such as the timesheet ID, employee ID, start and end dates, total hours, and the last updated date.`,
+  {
+    timesheetID: z.string().describe("The ID of the timesheet to retrieve."),
+  },
+  async (params: { timesheetID: string }) => {
+    const { timesheetID } = params;
+    const response = await getXeroPayrollTimesheet(timesheetID);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error retrieving timesheet: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const timesheet = response.result;
+
+    if (!timesheet) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `No timesheet found with ID: ${timesheetID}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            `Timesheet ID: ${timesheet.timesheetID}`,
+            `Employee ID: ${timesheet.employeeID}`,
+            `Start Date: ${timesheet.startDate}`,
+            `End Date: ${timesheet.endDate}`,
+            `Total Hours: ${timesheet.totalHours}`,
+            `Last Updated: ${timesheet.updatedDateUTC}`,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default GetPayrollTimesheetTool;

--- a/src/tools/list/list-payroll-timesheets.tool.ts
+++ b/src/tools/list/list-payroll-timesheets.tool.ts
@@ -1,0 +1,53 @@
+import { Timesheet } from "xero-node/dist/gen/model/payroll-nz/timesheet.js";
+
+import {
+  listXeroPayrollTimesheets,
+} from "../../handlers/list-xero-timesheets.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const ListPayrollTimesheetsTool = CreateXeroTool(
+  "list-timesheets",
+  `List all payroll timesheets in Xero.
+This retrieves comprehensive timesheet details including timesheet IDs, employee IDs, start and end dates, total hours, and the last updated date.`,
+  {},
+  async () => {
+    const response = await listXeroPayrollTimesheets();
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing timesheets: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const timesheets = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${timesheets?.length || 0} timesheets:`,
+        },
+        ...(timesheets?.map((timesheet: Timesheet) => ({
+          type: "text" as const,
+          text: [
+            `Timesheet ID: ${timesheet.timesheetID}`,
+            `Employee ID: ${timesheet.employeeID}`,
+            `Start Date: ${timesheet.startDate}`,
+            `End Date: ${timesheet.endDate}`,
+            `Total Hours: ${timesheet.totalHours}`,
+            `Last Updated: ${timesheet.updatedDateUTC}`,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPayrollTimesheetsTool;

--- a/src/tools/update/approve-payroll-timesheet.tool.ts
+++ b/src/tools/update/approve-payroll-timesheet.tool.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+import {
+  approveXeroPayrollTimesheet,
+} from "../../handlers/approve-xero-payroll-timesheet.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const ApprovePayrollTimesheetTool = CreateXeroTool(
+  "approve-timesheet",
+  `Approve a payroll timesheet in Xero by its ID.`,
+  {
+    timesheetID: z.string().describe("The ID of the timesheet to approve."),
+  },
+  async (params: { timesheetID: string }) => {
+    const { timesheetID } = params;
+    const response = await approveXeroPayrollTimesheet(timesheetID);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error approving timesheet: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const timesheet = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Successfully approved timesheet with ID: ${timesheet?.timesheetID}`,
+        },
+      ],
+    };
+  },
+);
+
+export default ApprovePayrollTimesheetTool;

--- a/src/tools/update/revert-payroll-timesheet.tool.ts
+++ b/src/tools/update/revert-payroll-timesheet.tool.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+import {
+  revertXeroPayrollTimesheet,
+} from "../../handlers/revert-xero-payroll-timesheet.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const RevertPayrollTimesheetTool = CreateXeroTool(
+  "revert-timesheet",
+  `Revert a payroll timesheet to draft in Xero by its ID.`,
+  {
+    timesheetID: z.string().describe("The ID of the timesheet to revert."),
+  },
+  async (params: { timesheetID: string }) => {
+    const { timesheetID } = params;
+    const response = await revertXeroPayrollTimesheet(timesheetID);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error reverting timesheet: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const timesheet = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Successfully reverted timesheet with ID: ${timesheet?.timesheetID} to draft.`,
+        },
+      ],
+    };
+  },
+);
+
+export default RevertPayrollTimesheetTool;

--- a/src/tools/update/update-payroll-timesheet-add-line.tool.ts
+++ b/src/tools/update/update-payroll-timesheet-add-line.tool.ts
@@ -1,0 +1,50 @@
+import {
+  TimesheetLine,
+} from "xero-node/dist/gen/model/payroll-nz/timesheetLine.js";
+import { z } from "zod";
+
+import {
+  updateXeroPayrollTimesheetAddLine,
+} from "../../handlers/update-xero-payroll-timesheet-add-line.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const AddTimesheetLineTool = CreateXeroTool(
+  "add-timesheet-line",
+  `Add a new timesheet line to an existing payroll timesheet in Xero.`,
+  {
+    timesheetID: z.string().describe("The ID of the timesheet to update."),
+    timesheetLine: z.object({
+      earningsRateID: z.string().describe("The ID of the earnings rate."),
+      numberOfUnits: z.number().describe("The number of units for the timesheet line."),
+      date: z.string().describe("The date for the timesheet line (YYYY-MM-DD)."),
+    }).describe("The details of the timesheet line to add."),
+  },
+  async (params: { timesheetID: string; timesheetLine: TimesheetLine }) => {
+    const { timesheetID, timesheetLine } = params;
+    const response = await updateXeroPayrollTimesheetAddLine(timesheetID, timesheetLine);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error adding timesheet line: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const newLine = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Successfully added timesheet line with date: ${newLine?.date}`,
+        },
+      ],
+    };
+  },
+);
+
+export default AddTimesheetLineTool;

--- a/src/tools/update/update-payroll-timesheet-update-line.tool.ts
+++ b/src/tools/update/update-payroll-timesheet-update-line.tool.ts
@@ -1,0 +1,51 @@
+import {
+  TimesheetLine,
+} from "xero-node/dist/gen/model/payroll-nz/timesheetLine.js";
+import { z } from "zod";
+
+import {
+  updateXeroPayrollTimesheetUpdateLine,
+} from "../../handlers/update-xero-payroll-timesheet-update-line.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const UpdatePayrollTimesheetLineTool = CreateXeroTool(
+  "update-timesheet-line",
+  `Update an existing timesheet line in a payroll timesheet in Xero.`,
+  {
+    timesheetID: z.string().describe("The ID of the timesheet to update."),
+    timesheetLineID: z.string().describe("The ID of the timesheet line to update."),
+    timesheetLine: z.object({
+      earningsRateID: z.string().describe("The ID of the earnings rate."),
+      numberOfUnits: z.number().describe("The number of units for the timesheet line."),
+      date: z.string().describe("The date for the timesheet line (YYYY-MM-DD)."),
+    }).describe("The details of the timesheet line to update."),
+  },
+  async (params: { timesheetID: string; timesheetLineID: string; timesheetLine: TimesheetLine }) => {
+    const { timesheetID, timesheetLineID, timesheetLine } = params;
+    const response = await updateXeroPayrollTimesheetUpdateLine(timesheetID, timesheetLineID, timesheetLine);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error updating timesheet line: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const updatedLine = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Successfully updated timesheet line with date: ${updatedLine?.date}`,
+        },
+      ],
+    };
+  },
+);
+
+export default UpdatePayrollTimesheetLineTool;


### PR DESCRIPTION
Tested working with `npm run build`