### PR TITLE
Add Docker HTTP transport and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+npm-debug.log*
+.git
+.gitignore
+.DS_Store
+backlog
+examples
+coverage
+.vscode
+.idea
+*.local
+.env
+.env.*

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Xero API Configuration for Custom Connections
 XERO_CLIENT_ID=your_client_id_here
 XERO_CLIENT_SECRET=your_client_secret_here 
+
+# Optional: protect HTTP transport with a shared secret
+MCP_API_KEY=optional_shared_secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies with the lockfile to ensure reproducible builds
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+# Copy the source and build outputs
+COPY tsconfig.json ./
+COPY src ./src
+
+# Compile TypeScript sources to JavaScript
+RUN npm run build
+
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Install only production dependencies
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+
+# Copy build output from the builder stage
+COPY --from=builder /app/dist dist
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD node -e "const http = require('http'); const port = process.env.PORT || 3000; http.get({ host: '127.0.0.1', port, path: '/healthz' }, (res) => { process.exit(res.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"
+
+CMD ["node", "dist/server.js"]

--- a/examples/http-read-only-test.mjs
+++ b/examples/http-read-only-test.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+/**
+ * Simple harness that spins up the HTTP MCP server, authenticates with the configured
+ * MCP_API_KEY, and runs a read-only tool (defaults to list-organisation-details).
+ *
+ * Usage:
+ *   MCP_API_KEY=secret XERO_CLIENT_ID=... XERO_CLIENT_SECRET=... node examples/http-read-only-test.mjs
+ *
+ * Optional environment variables:
+ *   MCP_TEST_TOOL   - tool name to call (default: list-organisation-details)
+ *   MCP_TEST_PORT   - port to bind the HTTP server (default: 3300)
+ *   MCP_TEST_HOST   - host to bind the HTTP server (default: 127.0.0.1)
+ */
+
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createInterface } from "node:readline";
+import { setTimeout as delay } from "node:timers/promises";
+import process from "node:process";
+import dotenv from "dotenv";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+
+dotenv.config();
+
+const TOOL_NAME = process.env.MCP_TEST_TOOL ?? "list-organisation-details";
+const HOST = process.env.MCP_TEST_HOST ?? "127.0.0.1";
+const PORT = Number.parseInt(process.env.MCP_TEST_PORT ?? "3300", 10);
+const API_KEY = process.env.MCP_API_KEY ?? "";
+const SKIP_SPAWN = process.env.MCP_TEST_SKIP_SPAWN === "true";
+
+if (!API_KEY) {
+  console.error("MCP_API_KEY must be set to authenticate against the HTTP server.");
+  process.exit(1);
+}
+
+const serverEnv = {
+  ...process.env,
+  HOST,
+  PORT: String(PORT),
+};
+
+const server = SKIP_SPAWN
+  ? null
+  : spawn("node", ["dist/server.js"], {
+      env: serverEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+const cleanup = async () => {
+  if (!server || SKIP_SPAWN || server.killed) {
+    return;
+  }
+  if (!server.killed) {
+    server.kill();
+    await once(server, "exit").catch(() => {});
+  }
+};
+
+if (server) {
+  server.on("exit", (code, signal) => {
+    if (code !== 0) {
+      console.error(`HTTP server exited unexpectedly (code=${code}, signal=${signal})`);
+    }
+  });
+
+  server.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+  });
+}
+
+const waitForServer = async () => {
+  if (SKIP_SPAWN) {
+    const healthUrl = new URL(`http://${HOST}:${PORT}/healthz`);
+    const deadline = Date.now() + 15000;
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(healthUrl);
+        if (response.ok) {
+          return;
+        }
+      } catch (error) {
+        // Swallow and retry until deadline expires
+      }
+      await delay(250);
+    }
+    throw new Error(`Timed out waiting for remote server at ${healthUrl.href}`);
+  }
+
+  if (!server) {
+    throw new Error("Server process not started and SKIP_SPAWN disabled.");
+  }
+
+  const readline = createInterface({ input: server.stdout });
+  try {
+    for await (const line of readline) {
+      if (line.includes("HTTP MCP server listening")) {
+        return;
+      }
+      process.stdout.write(`${line}\n`);
+    }
+  } finally {
+    readline.close();
+  }
+
+  throw new Error("Server exited before signaling readiness.");
+};
+
+const run = async () => {
+  await waitForServer();
+
+  const serverUrl = new URL(`http://${HOST}:${PORT}/mcp`);
+  const headers = { Authorization: `Bearer ${API_KEY}` };
+
+  const transport = new SSEClientTransport(serverUrl, {
+    requestInit: { headers },
+    eventSourceInit: {
+      fetch: async (resource, init) => {
+        const mergedHeaders = new Headers(init?.headers ?? {});
+        mergedHeaders.set("Authorization", `Bearer ${API_KEY}`);
+        return fetch(resource, { ...init, headers: mergedHeaders });
+      },
+    },
+  });
+
+  const client = new Client(
+    { name: "xero-mcp-read-test", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  try {
+    await client.connect(transport);
+    console.log(`Connected to MCP server at ${serverUrl.href}`);
+
+    const tools = await client.listTools({});
+    const hasTool = tools.tools.some((tool) => tool.name === TOOL_NAME);
+    if (!hasTool) {
+      throw new Error(
+        `Tool "${TOOL_NAME}" not advertised by server. Available tools: ${tools.tools
+          .map((tool) => tool.name)
+          .join(", ")}`,
+      );
+    }
+
+    console.log(`Calling read-only tool "${TOOL_NAME}"...`);
+    const result = await client.callTool({
+      name: TOOL_NAME,
+      arguments: {},
+    });
+
+    console.log("Tool response:");
+    console.log(JSON.stringify(result, null, 2));
+  } finally {
+    await client.close().catch(() => {});
+    await cleanup();
+  }
+};
+
+run()
+  .then(() => delay(100))
+  .catch(async (error) => {
+    console.error("Read-only harness failed:", error);
+    await cleanup();
+    process.exit(1);
+  });

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -11,9 +11,9 @@ import { ensureError } from "../helpers/ensure-error.js";
 
 dotenv.config();
 
-const client_id = process.env.XERO_CLIENT_ID;
-const client_secret = process.env.XERO_CLIENT_SECRET;
-const bearer_token = process.env.XERO_CLIENT_BEARER_TOKEN;
+const client_id = process.env.XERO_CLIENT_ID?.trim();
+const client_secret = process.env.XERO_CLIENT_SECRET?.trim();
+const bearer_token = process.env.XERO_CLIENT_BEARER_TOKEN?.trim();
 const grant_type = "client_credentials";
 
 if (!bearer_token && (!client_id || !client_secret)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import dotenv from "dotenv";
+import { URL } from "node:url";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { XeroMcpServer } from "./server/xero-mcp-server.js";
+import { ToolFactory } from "./tools/tool-factory.js";
+
+dotenv.config();
+
+const DEFAULT_PORT = 3000;
+const HEALTH_PATH = "/healthz";
+const MCP_PATH = "/mcp";
+
+type Session = {
+  transport: SSEServerTransport;
+  server: McpServer;
+};
+
+const sessions = new Map<string, Session>();
+
+const mcpApiKey = process.env.MCP_API_KEY;
+const isAuthEnabled = typeof mcpApiKey === "string" && mcpApiKey.length > 0;
+
+const getAuthorizationHeader = (req: IncomingMessage): string | undefined => {
+  const header = req.headers.authorization;
+  if (!header) {
+    return undefined;
+  }
+
+  return Array.isArray(header) ? header[0] : header;
+};
+
+const hasValidBearerToken = (authorizationHeader: string): boolean => {
+  const match = /^Bearer\s+(.+)$/i.exec(authorizationHeader);
+  if (!match) {
+    return false;
+  }
+
+  const token = match[1]?.trim();
+  return Boolean(token) && token === mcpApiKey;
+};
+
+const isAuthorizedRequest = (req: IncomingMessage): boolean => {
+  if (!isAuthEnabled) {
+    return true;
+  }
+
+  const authorizationHeader = getAuthorizationHeader(req);
+  if (!authorizationHeader) {
+    return false;
+  }
+
+  return hasValidBearerToken(authorizationHeader);
+};
+
+const rejectUnauthorized = (res: ServerResponse): void => {
+  if (!res.headersSent) {
+    res.writeHead(401, {
+      "Content-Type": "text/plain",
+      "WWW-Authenticate": 'Bearer realm="xero-mcp-server"',
+    });
+  }
+  res.end("Missing or invalid MCP API key");
+};
+
+const resolvePort = (): number => {
+  const configured = Number.parseInt(process.env.PORT ?? "", 10);
+  return Number.isNaN(configured) ? DEFAULT_PORT : configured;
+};
+
+const host = process.env.HOST ?? "0.0.0.0";
+const port = resolvePort();
+
+const buildServerWithTools = (): McpServer => {
+  const server = XeroMcpServer.CreateServerInstance();
+  ToolFactory(server);
+  return server;
+};
+
+const handleHealthz = (_req: IncomingMessage, res: ServerResponse): void => {
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end("ok");
+};
+
+const handleSseConnection = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> => {
+  if (req.method !== "GET") {
+    res.writeHead(405, { Allow: "GET, POST" });
+    res.end("Method Not Allowed");
+    return;
+  }
+
+  const server = buildServerWithTools();
+  const transport = new SSEServerTransport(MCP_PATH, res);
+  const sessionId = transport.sessionId;
+
+  sessions.set(sessionId, { transport, server });
+
+  transport.onclose = async () => {
+    sessions.delete(sessionId);
+    try {
+      await server.close();
+    } catch (error) {
+      console.error("Error closing MCP server:", error);
+    }
+  };
+
+  transport.onerror = (error) => {
+    console.error("SSE transport error:", error);
+  };
+
+  try {
+    await server.connect(transport);
+  } catch (error) {
+    sessions.delete(sessionId);
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("Failed to initialize MCP session");
+    }
+    console.error("Failed to establish MCP SSE session:", error);
+  }
+};
+
+const handleMcpPost = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): Promise<void> => {
+  if (req.method !== "POST") {
+    res.writeHead(405, { Allow: "GET, POST" });
+    res.end("Method Not Allowed");
+    return;
+  }
+
+  const sessionId = url.searchParams.get("sessionId");
+  if (!sessionId) {
+    res.writeHead(400, { "Content-Type": "text/plain" });
+    res.end("Missing sessionId");
+    return;
+  }
+
+  const session = sessions.get(sessionId);
+  if (!session) {
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("Session not found");
+    return;
+  }
+
+  try {
+    await session.transport.handlePostMessage(req, res);
+  } catch (error) {
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("Failed to handle MCP message");
+    }
+    console.error("Failed to handle MCP POST:", error);
+  }
+};
+
+const server = createServer(async (req, res) => {
+  try {
+    if (!req.url) {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end("Invalid request");
+      return;
+    }
+
+    const requestUrl = new URL(
+      req.url,
+      `http://${req.headers.host ?? `${host}:${port}`}`,
+    );
+
+    if (requestUrl.pathname === HEALTH_PATH && req.method === "GET") {
+      handleHealthz(req, res);
+      return;
+    }
+
+    if (requestUrl.pathname === MCP_PATH) {
+      if (!isAuthorizedRequest(req)) {
+        rejectUnauthorized(res);
+        return;
+      }
+
+      if (req.method === "GET") {
+        await handleSseConnection(req, res);
+        return;
+      }
+
+      await handleMcpPost(req, res, requestUrl);
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("Not Found");
+  } catch (error) {
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("Internal Server Error");
+    }
+    console.error("Unhandled server error:", error);
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`HTTP MCP server listening on http://${host}:${port}`);
+});

--- a/src/server/xero-mcp-server.ts
+++ b/src/server/xero-mcp-server.ts
@@ -5,16 +5,24 @@ export class XeroMcpServer {
 
   private constructor() {}
 
+  private static createServer(): McpServer {
+    return new McpServer({
+      name: "Xero MCP Server",
+      version: "1.0.0",
+      capabilities: {
+        tools: {},
+      },
+    });
+  }
+
   public static GetServer(): McpServer {
     if (XeroMcpServer.instance === null) {
-      XeroMcpServer.instance = new McpServer({
-        name: "Xero MCP Server",
-        version: "1.0.0",
-        capabilities: {
-          tools: {},
-        },
-      });
+      XeroMcpServer.instance = XeroMcpServer.createServer();
     }
     return XeroMcpServer.instance;
+  }
+
+  public static CreateServerInstance(): McpServer {
+    return XeroMcpServer.createServer();
   }
 }


### PR DESCRIPTION
## Summary

  - add src/server.ts SSE/HTTP transport that boots a fresh XeroMcpServer instance per session, guards /mcp behind an
    optional MCP_API_KEY, and exposes /healthz
  - ship a multi-stage Dockerfile and .dockerignore, trimming runtime dependencies and wiring a health check for container
    deployments
  - document the new transport, env vars, and verification checklist in README.md, and surface MCP_API_KEY in .env.example
  - include examples/http-read-only-test.mjs to exercise read-only tools over HTTP and tighten XeroMcpServer/ToolFactory wiring to support repeated instantiation
  - trim credential environment variables in xero-client to avoid whitespace issues reported by Xero

  ## Configuration changes

  - introduce MCP_API_KEY (recommended for HTTP transport authentication)
  - support optional HOST/PORT overrides when running dist/server.js or the Docker image