### PR TITLE
fix: use VOIDED instead of VOID for manual journal status enum

### DIFF
--- a/src/tools/create/create-manual-journal.tool.ts
+++ b/src/tools/create/create-manual-journal.tool.ts
@@ -47,10 +47,10 @@ const CreateManualJournalTool = CreateXeroTool(
         "Optional line amount types (EXCLUSIVE, INCLUSIVE, NO_TAX), NO_TAX by default",
       ),
     status: z
-      .enum(["DRAFT", "POSTED", "DELETED", "VOID", "ARCHIVED"])
+      .enum(["DRAFT", "POSTED", "DELETED", "VOIDED", "ARCHIVED"])
       .optional()
       .describe(
-        "Optional status of the manual journal (DRAFT, POSTED, DELETED, VOID, ARCHIVED), DRAFT by default",
+        "Optional status of the manual journal (DRAFT, POSTED, DELETED, VOIDED, ARCHIVED), DRAFT by default",
       ),
     url: z
       .string()

--- a/src/tools/update/update-manual-journal-tool.ts
+++ b/src/tools/update/update-manual-journal-tool.ts
@@ -45,10 +45,10 @@ const UpdateManualJournalTool = CreateXeroTool(
         "Optional line amount types (EXCLUSIVE, INCLUSIVE, NO_TAX), NO_TAX by default",
       ),
     status: z
-      .enum(["DRAFT", "POSTED", "DELETED", "VOID", "ARCHIVED"])
+      .enum(["DRAFT", "POSTED", "DELETED", "VOIDED", "ARCHIVED"])
       .optional()
       .describe(
-        "Optional status of the manual journal (DRAFT, POSTED, DELETED, VOID, ARCHIVED), DRAFT by default",
+        "Optional status of the manual journal (DRAFT, POSTED, DELETED, VOIDED, ARCHIVED), DRAFT by default",
       ),
     url: z
       .string()


### PR DESCRIPTION
## Summary

- Fixed incorrect status enum value in manual journal tools
- Changed `VOID` to `VOIDED` to match the `ManualJournal.StatusEnum` defined in xero-node

## Problem

When attempting to void a manual journal via the API, the MCP server was sending `VOID` as the status value, but the Xero API expects `VOIDED`. This caused validation errors:

```
"The status 'VOID' cannot be applied to the document"
```

## Solution

Updated the zod enum in both `create-manual-journal.tool.ts` and `update-manual-journal-tool.ts` to use `VOIDED` instead of `VOID`, matching the `ManualJournal.StatusEnum` definition in the xero-node package.

## Files Changed

- `src/tools/create/create-manual-journal.tool.ts`
- `src/tools/update/update-manual-journal-tool.ts`

## Test Plan

- [x] Verified fix compiles successfully with `npm run build`
- [ ] Test voiding a manual journal via the MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)