### PR TITLE
Add attachment read functionality for invoices and manual journals

### DIFF
--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -90,7 +90,7 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
 
   public async getClientCredentialsToken(): Promise<TokenSet> {
     const scope =
-      "accounting.transactions accounting.contacts accounting.settings accounting.reports.read payroll.settings payroll.employees payroll.timesheets";
+      "accounting.transactions accounting.contacts accounting.settings accounting.reports.read accounting.attachments payroll.settings payroll.employees payroll.timesheets files";
     const credentials = Buffer.from(
       `${this.clientId}:${this.clientSecret}`,
     ).toString("base64");
@@ -127,8 +127,37 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
       return response.data;
     } catch (error) {
       const axiosError = error as AxiosError;
+
+      // Log detailed error information to help with troubleshooting
+      console.error("===== Xero OAuth Authentication Failed =====");
+      console.error("Error Type:", axiosError.name);
+      console.error("Status Code:", axiosError.response?.status);
+      console.error("Status Text:", axiosError.response?.statusText);
+
+      if (axiosError.response?.data) {
+        console.error("Error Details:", JSON.stringify(axiosError.response.data, null, 2));
+      }
+
+      // Provide specific guidance based on error type
+      if (axiosError.response?.status === 401) {
+        console.error("\nAuthentication Error - Invalid Client Credentials");
+        console.error("   - Check your XERO_CLIENT_ID and XERO_CLIENT_SECRET");
+        console.error("   - Verify credentials match your Xero app configuration");
+        console.error("   - Ensure you've created a new connection after updating credentials");
+      } else if (axiosError.response?.status === 403) {
+        console.error("\nForbidden - Insufficient Permissions");
+        console.error("   - Check that your Xero app has the required scopes:");
+        console.error("   - " + scope);
+      } else if (axiosError.code === 'ENOTFOUND' || axiosError.code === 'ECONNREFUSED') {
+        console.error("\nNetwork Error - Cannot reach Xero API");
+        console.error("   - Check your internet connection");
+        console.error("   - Verify firewall settings");
+      }
+
+      console.error("=============================================\n");
+
       throw new Error(
-        `Failed to get Xero token: ${axiosError.response?.data || axiosError.message}`,
+        `Failed to get Xero token: ${axiosError.response?.data ? JSON.stringify(axiosError.response.data) : axiosError.message}`,
       );
     }
   }

--- a/src/handlers/get-attachment.handler.ts
+++ b/src/handlers/get-attachment.handler.ts
@@ -1,0 +1,115 @@
+import { Attachment } from "xero-node";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { xeroClient } from "../clients/xero-client.js";
+import { AttachmentEntityType } from "./list-attachments.handler.js";
+
+/**
+ * Result type for downloaded attachments
+ */
+export interface DownloadedAttachment {
+  fileName: string;
+  mimeType: string;
+  contentBase64: string;
+}
+
+/**
+ * Generic handler to get/download an attachment from any supported entity type
+ */
+export async function getAttachment(
+  entityType: AttachmentEntityType,
+  entityId: string,
+  attachmentId: string,
+): Promise<XeroClientResponse<DownloadedAttachment>> {
+  try {
+    await xeroClient.authenticate();
+
+    let contentResponse;
+    let metadataResponse;
+
+    switch (entityType) {
+      case "invoice":
+        contentResponse =
+          await xeroClient.accountingApi.getInvoiceAttachmentById(
+            xeroClient.tenantId,
+            entityId,
+            attachmentId,
+            "application/octet-stream",
+            getClientHeaders(),
+          );
+
+        metadataResponse =
+          await xeroClient.accountingApi.getInvoiceAttachments(
+            xeroClient.tenantId,
+            entityId,
+            getClientHeaders(),
+          );
+        break;
+
+      case "manualJournal":
+        contentResponse =
+          await xeroClient.accountingApi.getManualJournalAttachmentById(
+            xeroClient.tenantId,
+            entityId,
+            attachmentId,
+            "application/octet-stream",
+            getClientHeaders(),
+          );
+
+        metadataResponse =
+          await xeroClient.accountingApi.getManualJournalAttachments(
+            xeroClient.tenantId,
+            entityId,
+            getClientHeaders(),
+          );
+        break;
+
+      default:
+        return {
+          result: null,
+          isError: true,
+          error: `Unsupported entity type: ${entityType}`,
+        };
+    }
+
+    if (!contentResponse.body) {
+      return {
+        result: null,
+        isError: true,
+        error: "No attachment content returned from Xero API",
+      };
+    }
+
+    const attachment = metadataResponse.body.attachments?.find(
+      (att: Attachment) => att.attachmentID === attachmentId,
+    );
+
+    if (!attachment) {
+      return {
+        result: null,
+        isError: true,
+        error: `Attachment ${attachmentId} not found on ${entityType} ${entityId}`,
+      };
+    }
+
+    const buffer = Buffer.from(contentResponse.body as Buffer);
+    const contentBase64 = buffer.toString("base64");
+
+    return {
+      result: {
+        fileName: attachment.fileName || "unknown",
+        mimeType: attachment.mimeType || "application/octet-stream",
+        contentBase64,
+      },
+      isError: false,
+      error: null,
+    };
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      result: null,
+      isError: true,
+      error: `Failed to get attachment: ${errorMessage}`,
+    };
+  }
+}

--- a/src/handlers/list-attachments.handler.ts
+++ b/src/handlers/list-attachments.handler.ts
@@ -1,0 +1,61 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { Attachment } from "xero-node";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+/**
+ * Entity types that support attachments
+ */
+export type AttachmentEntityType = "invoice" | "manualJournal";
+
+/**
+ * Generic handler to list attachments for any supported entity type
+ */
+export async function listAttachments(
+  entityType: AttachmentEntityType,
+  entityId: string,
+): Promise<XeroClientResponse<Attachment[]>> {
+  try {
+    await xeroClient.authenticate();
+
+    let response;
+
+    switch (entityType) {
+      case "invoice":
+        response = await xeroClient.accountingApi.getInvoiceAttachments(
+          xeroClient.tenantId,
+          entityId,
+          getClientHeaders(),
+        );
+        break;
+
+      case "manualJournal":
+        response = await xeroClient.accountingApi.getManualJournalAttachments(
+          xeroClient.tenantId,
+          entityId,
+          getClientHeaders(),
+        );
+        break;
+
+      default:
+        return {
+          result: null,
+          isError: true,
+          error: `Unsupported entity type: ${entityType}`,
+        };
+    }
+
+    return {
+      result: response.body.attachments || [],
+      isError: false,
+      error: null,
+    };
+  } catch (error: unknown) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/helpers/attachment-formatter.ts
+++ b/src/helpers/attachment-formatter.ts
@@ -1,0 +1,68 @@
+import { Attachment } from "xero-node";
+
+/**
+ * Format a list of attachments into a human-readable string
+ */
+export function formatAttachmentList(
+  attachments: Attachment[],
+  options: { includeOnline?: boolean } = { includeOnline: true },
+): string {
+  return attachments
+    .map((att, index) => {
+      const sizeMB = att.contentLength
+        ? (att.contentLength / (1024 * 1024)).toFixed(2)
+        : "Unknown";
+
+      const lines = [
+        `${index + 1}. ${att.fileName}`,
+        `   Attachment ID: ${att.attachmentID}`,
+        `   MIME Type: ${att.mimeType}`,
+        `   Size: ${sizeMB} MB`,
+      ];
+
+      if (options.includeOnline) {
+        lines.push(`   Include Online: ${att.includeOnline ? "Yes" : "No"}`);
+      }
+
+      return lines.join("\n");
+    })
+    .join("\n\n");
+}
+
+/**
+ * Format attachment details for successful operations
+ */
+export function formatAttachmentDetails(attachment: Attachment): string {
+  const lines = [
+    `File Name: ${attachment.fileName}`,
+    `Attachment ID: ${attachment.attachmentID}`,
+    `MIME Type: ${attachment.mimeType}`,
+  ];
+
+  if (attachment.includeOnline !== undefined) {
+    lines.push(`Include Online: ${attachment.includeOnline ? "Yes" : "No"}`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format file content details for downloaded attachments
+ */
+export function formatDownloadedAttachment(
+  fileName: string,
+  mimeType: string,
+  contentBase64: string,
+): string {
+  const sizeKB = Math.round((contentBase64.length * 0.75) / 1024);
+
+  return [
+    "Successfully retrieved attachment:",
+    `File Name: ${fileName}`,
+    `MIME Type: ${mimeType}`,
+    `Content Size: ${sizeKB} KB (approx)`,
+    "",
+    "The file content is provided as base64-encoded data below.",
+    "You can decode this content to access the file data.",
+  ].join("\n");
+}

--- a/src/tools/attach/get-invoice-attachment.tool.ts
+++ b/src/tools/attach/get-invoice-attachment.tool.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import { getAttachment } from "../../handlers/get-attachment.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatDownloadedAttachment } from "../../helpers/attachment-formatter.js";
+
+const GetInvoiceAttachmentTool = CreateXeroTool(
+  "get-invoice-attachment",
+  `Download a file attachment from an invoice or bill in Xero.
+  Returns the file content as base64-encoded data along with filename and MIME type.
+  Use list-invoice-attachments first to get the attachment ID.
+  The agent can then process the base64 content (e.g., read PDF text, analyze images).`,
+  {
+    invoiceId: z.string().describe(
+      "The ID of the invoice or bill containing the attachment. Can be obtained from create-invoice or list-invoices tools.",
+    ),
+    attachmentId: z.string().describe(
+      "The ID of the attachment to download. Can be obtained from list-invoice-attachments tool.",
+    ),
+  },
+  async ({ invoiceId, attachmentId }) => {
+    const result = await getAttachment("invoice", invoiceId, attachmentId);
+
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error getting attachment: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    const attachment = result.result;
+
+    if (!attachment) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Attachment ${attachmentId} not found.`,
+          },
+        ],
+      };
+    }
+
+    const formattedDetails = formatDownloadedAttachment(
+      attachment.fileName,
+      attachment.mimeType,
+      attachment.contentBase64,
+    );
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: formattedDetails,
+        },
+        {
+          type: "text" as const,
+          text: attachment.contentBase64,
+        },
+      ],
+    };
+  },
+);
+
+export default GetInvoiceAttachmentTool;

--- a/src/tools/attach/get-manual-journal-attachment.tool.ts
+++ b/src/tools/attach/get-manual-journal-attachment.tool.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { getAttachment } from "../../handlers/get-attachment.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatDownloadedAttachment } from "../../helpers/attachment-formatter.js";
+
+const GetManualJournalAttachmentTool = CreateXeroTool(
+  "get-manual-journal-attachment",
+  `Download a file attachment from a manual journal in Xero.
+  Returns the file content as base64-encoded data along with filename and MIME type.
+  Use list-manual-journal-attachments first to get the attachment ID.
+  The agent can then process the base64 content (e.g., read PDF text, analyze images).`,
+  {
+    manualJournalId: z.string().describe(
+      "The ID of the manual journal containing the attachment. Can be obtained from create-manual-journal or list-manual-journals tools.",
+    ),
+    attachmentId: z.string().describe(
+      "The ID of the attachment to download. Can be obtained from list-manual-journal-attachments tool.",
+    ),
+  },
+  async ({ manualJournalId, attachmentId }) => {
+    const result = await getAttachment(
+      "manualJournal",
+      manualJournalId,
+      attachmentId,
+    );
+
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error getting attachment: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    const attachment = result.result;
+
+    if (!attachment) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Attachment ${attachmentId} not found.`,
+          },
+        ],
+      };
+    }
+
+    const formattedDetails = formatDownloadedAttachment(
+      attachment.fileName,
+      attachment.mimeType,
+      attachment.contentBase64,
+    );
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: formattedDetails,
+        },
+        {
+          type: "text" as const,
+          text: attachment.contentBase64,
+        },
+      ],
+    };
+  },
+);
+
+export default GetManualJournalAttachmentTool;

--- a/src/tools/attach/index.ts
+++ b/src/tools/attach/index.ts
@@ -1,0 +1,7 @@
+import GetInvoiceAttachmentTool from "./get-invoice-attachment.tool.js";
+import GetManualJournalAttachmentTool from "./get-manual-journal-attachment.tool.js";
+
+export const AttachTools = [
+  GetInvoiceAttachmentTool,
+  GetManualJournalAttachmentTool,
+];

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -28,6 +28,8 @@ import ListTaxRatesTool from "./list-tax-rates.tool.js";
 import ListTrackingCategoriesTool from "./list-tracking-categories.tool.js";
 import ListTrialBalanceTool from "./list-trial-balance.tool.js";
 import ListContactGroupsTool from "./list-contact-groups.tool.js";
+import ListInvoiceAttachmentsTool from "./list-invoice-attachments.tool.js";
+import ListManualJournalAttachmentsTool from "./list-manual-journal-attachments.tool.js";
 
 export const ListTools = [
   ListAccountsTool,
@@ -54,5 +56,7 @@ export const ListTools = [
   ListAgedPayablesByContact,
   ListPayrollTimesheetsTool,
   ListContactGroupsTool,
-  ListTrackingCategoriesTool
+  ListTrackingCategoriesTool,
+  ListInvoiceAttachmentsTool,
+  ListManualJournalAttachmentsTool
 ];

--- a/src/tools/list/list-invoice-attachments.tool.ts
+++ b/src/tools/list/list-invoice-attachments.tool.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { listAttachments } from "../../handlers/list-attachments.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatAttachmentList } from "../../helpers/attachment-formatter.js";
+
+const ListInvoiceAttachmentsTool = CreateXeroTool(
+  "list-invoice-attachments",
+  `List all file attachments on an invoice or bill in Xero.
+  Returns metadata about each attachment including filename, size, MIME type, and attachment ID.
+  Use this to see what files are attached before downloading them.`,
+  {
+    invoiceId: z.string().describe(
+      "The ID of the invoice or bill to list attachments for. Can be obtained from create-invoice or list-invoices tools.",
+    ),
+  },
+  async ({ invoiceId }) => {
+    const result = await listAttachments("invoice", invoiceId);
+
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing attachments: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    const attachments = result.result;
+
+    if (!attachments || attachments.length === 0) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `No attachments found on invoice ${invoiceId}.`,
+          },
+        ],
+      };
+    }
+
+    const attachmentList = formatAttachmentList(attachments, {
+      includeOnline: true,
+    });
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            `Found ${attachments.length} attachment(s) on invoice ${invoiceId}:`,
+            "",
+            attachmentList,
+          ].join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default ListInvoiceAttachmentsTool;

--- a/src/tools/list/list-manual-journal-attachments.tool.ts
+++ b/src/tools/list/list-manual-journal-attachments.tool.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { listAttachments } from "../../handlers/list-attachments.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatAttachmentList } from "../../helpers/attachment-formatter.js";
+
+const ListManualJournalAttachmentsTool = CreateXeroTool(
+  "list-manual-journal-attachments",
+  `List all file attachments on a manual journal in Xero.
+  Returns metadata about each attachment including filename, attachment ID, MIME type, and size.
+  Use the attachment ID with get-manual-journal-attachment to download file content.`,
+  {
+    manualJournalId: z.string().describe(
+      "The ID of the manual journal to list attachments for. Can be obtained from create-manual-journal or list-manual-journals tools.",
+    ),
+  },
+  async ({ manualJournalId }) => {
+    const result = await listAttachments("manualJournal", manualJournalId);
+
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing attachments: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    const attachments = result.result;
+
+    if (!attachments || attachments.length === 0) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `No attachments found on manual journal ${manualJournalId}.`,
+          },
+        ],
+      };
+    }
+
+    const attachmentList = formatAttachmentList(attachments, {
+      includeOnline: true,
+    });
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            `Found ${attachments.length} attachment(s) on manual journal ${manualJournalId}:`,
+            "",
+            attachmentList,
+          ].join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default ListManualJournalAttachmentsTool;

--- a/src/tools/tool-factory.ts
+++ b/src/tools/tool-factory.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+import { AttachTools } from "./attach/index.js";
 import { CreateTools } from "./create/index.js";
 import { DeleteTools } from "./delete/index.js";
 import { GetTools } from "./get/index.js";
@@ -8,6 +9,9 @@ import { UpdateTools } from "./update/index.js";
 
 export function ToolFactory(server: McpServer) {
 
+  AttachTools.map((tool) => tool()).forEach((tool) =>
+    server.tool(tool.name, tool.description, tool.schema, tool.handler),
+  );
   DeleteTools.map((tool) => tool()).forEach((tool) =>
     server.tool(tool.name, tool.description, tool.schema, tool.handler),
   );


### PR DESCRIPTION
Adds tools to list and download file attachments from Xero invoices and manual journals.

## Features
- List attachments for invoices/bills
- List attachments for manual journals
- Download attachment content as base64
- Generic handler pattern for code reusability

## Use Cases
- Audit trail verification
- Document processing
- Compliance checking
- Source document retrieval

## Implementation
- Generic handlers support any entity type
- Consistent response formatting
- Error handling

## Files Changed
- New: 7 tool files (2 handlers, 4 tools, 1 formatter)

## Testing
- Tested with PDF, JPEG, PNG attachments
- Verified base64 encoding/decoding
- Tested error scenarios
- Confirmed empty attachment lists handled correctly