### PR TITLE
fix: use correct deep link URL for bills (ACCPAY) when updating invoices

### DIFF
--- a/src/tools/update/update-invoice.tool.ts
+++ b/src/tools/update/update-invoice.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { updateXeroInvoice } from "../../handlers/update-xero-invoice.handler.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { Invoice } from "xero-node";
 
 const trackingSchema = z.object({
   name: z.string().describe("The name of the tracking category. Can be obtained from the list-tracking-categories tool"),
@@ -90,7 +91,10 @@ const UpdateInvoiceTool = CreateXeroTool(
     const invoice = result.result;
 
     const deepLink = invoice.invoiceID
-      ? await getDeepLink(DeepLinkType.INVOICE, invoice.invoiceID)
+      ? await getDeepLink(
+          invoice.type === Invoice.TypeEnum.ACCREC ? DeepLinkType.INVOICE : DeepLinkType.BILL,
+          invoice.invoiceID,
+        )
       : null;
 
     return {


### PR DESCRIPTION
## Summary

Fixes #105 - When updating an invoice, the deep link URL was always using `/invoicing/view/` regardless of the invoice type. For bills (ACCPAY invoices), this URL does not work correctly in Xero's web interface.

**The fix:** Added the same type-checking logic that already exists in `create-invoice.tool.ts` to `update-invoice.tool.ts`:
- Sales invoices (ACCREC) → `DeepLinkType.INVOICE` → `/invoicing/view/`
- Bills (ACCPAY) → `DeepLinkType.BILL` → correct bill URL

## Changes

- Added `Invoice` import from `xero-node`
- Modified deep link generation to check `invoice.type` and use `DeepLinkType.BILL` for ACCPAY invoices

## Test plan

- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [ ] Manual test: Update an ACCPAY invoice and verify the returned deep link uses the bills path