### PR TITLE
Add browser-based OAuth authentication for all regions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,26 @@
-# Xero API Configuration for Custom Connections
+# Xero MCP Server Configuration
+# Choose ONE of the following authentication methods:
+
+# ============================================
+# Option 1: Browser-based OAuth (RECOMMENDED)
+# ============================================
+# Works in all regions, handles token refresh automatically.
+# First run opens browser for login, subsequent runs use saved tokens.
+XERO_USE_BROWSER_AUTH=true
 XERO_CLIENT_ID=your_client_id_here
-XERO_CLIENT_SECRET=your_client_secret_here 
+XERO_CLIENT_SECRET=your_client_secret_here
+# Optional: customize scopes (space-separated)
+# XERO_SCOPES=accounting.transactions accounting.contacts accounting.settings.read accounting.reports.read
+
+# ============================================
+# Option 2: Custom Connections (AU/NZ/UK/US only)
+# ============================================
+# Requires Custom Connection subscription in Xero.
+# XERO_CLIENT_ID=your_client_id_here
+# XERO_CLIENT_SECRET=your_client_secret_here
+
+# ============================================
+# Option 3: Bearer Token (manual refresh required)
+# ============================================
+# Token expires after 30 minutes.
+# XERO_CLIENT_BEARER_TOKEN=your_bearer_token_here

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@xeroapi/xero-mcp-server",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xeroapi/xero-mcp-server",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.4",
         "dotenv": "^16.4.7",
+        "open": "^11.0.0",
         "openid-client": "^6.8.1",
         "xero-node": "^13.3.0",
         "zod": "3.25"
@@ -393,6 +394,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -623,6 +625,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -764,6 +767,21 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bytes": {
@@ -960,6 +978,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
+      "integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1099,6 +1157,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1882,6 +1941,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1905,11 +1979,56 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2192,6 +2311,26 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openid-client": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.1.tgz",
@@ -2328,6 +2467,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2342,6 +2482,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prelude-ls": {
@@ -2514,6 +2666,18 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safe-buffer": {
@@ -2877,6 +3041,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2984,6 +3149,22 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xero-node": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/xero-node/-/xero-node-13.3.0.tgz",
@@ -3042,6 +3223,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "@xeroapi/xero-mcp-server",
-  "version": "0.0.13",
-  "description": "MCP server implementation for Xero integration",
+  "name": "xero-mcp-server-oauth",
+  "version": "0.1.0",
+  "description": "MCP server for Xero with browser-based OAuth (works in all regions)",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/XeroAPI/xero-mcp-server.git"
   },
-  "author": "Xero (https://xero.com)",
+  "author": "Fork of Xero MCP Server with OAuth browser flow",
   "type": "module",
   "bin": "./dist/index.js",
   "files": [
@@ -24,6 +24,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.23.4",
     "dotenv": "^16.4.7",
+    "open": "^11.0.0",
     "openid-client": "^6.8.1",
     "xero-node": "^13.3.0",
     "zod": "3.25"

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -1,4 +1,11 @@
+import { createServer, IncomingMessage, ServerResponse } from "http";
+import { URL, URLSearchParams } from "url";
+import crypto from "crypto";
 import axios, { AxiosError } from "axios";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import open from "open";
 import dotenv from "dotenv";
 import {
   IXeroClientConfig,
@@ -11,15 +18,58 @@ import { ensureError } from "../helpers/ensure-error.js";
 
 dotenv.config();
 
+// Environment variables
 const client_id = process.env.XERO_CLIENT_ID;
 const client_secret = process.env.XERO_CLIENT_SECRET;
 const bearer_token = process.env.XERO_CLIENT_BEARER_TOKEN;
+const use_browser_auth = process.env.XERO_USE_BROWSER_AUTH === "true";
+const scopes =
+  process.env.XERO_SCOPES ||
+  "accounting.transactions accounting.contacts accounting.settings accounting.reports.read";
 const grant_type = "client_credentials";
 
-if (!bearer_token && (!client_id || !client_secret)) {
+// OAuth browser flow constants
+const TOKEN_FILE = path.join(os.homedir(), ".xero-mcp-tokens.json");
+const CALLBACK_PORT = 8749; // Uncommon port to avoid conflicts
+const CALLBACK_PATH = "/callback";
+const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
+const AUTHORIZE_URL = "https://login.xero.com/identity/connect/authorize";
+const TOKEN_URL = "https://identity.xero.com/connect/token";
+
+// Validate environment variables based on auth method
+if (use_browser_auth) {
+  if (!client_id || !client_secret) {
+    throw Error(
+      "XERO_USE_BROWSER_AUTH=true requires XERO_CLIENT_ID and XERO_CLIENT_SECRET"
+    );
+  }
+} else if (!bearer_token && (!client_id || !client_secret)) {
   throw Error("Environment Variables not set - please check your .env file");
 }
 
+// PKCE helpers
+function generateCodeVerifier(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+function generateCodeChallenge(verifier: string): string {
+  return crypto.createHash("sha256").update(verifier).digest("base64url");
+}
+
+function generateState(): string {
+  return crypto.randomBytes(16).toString("hex");
+}
+
+// Token storage interface
+interface StoredTokens {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  id_token?: string;
+  scope: string;
+}
+
+// Base class for all MCP Xero clients
 abstract class MCPXeroClient extends XeroClient {
   public tenantId: string;
   private shortCode: string;
@@ -45,7 +95,7 @@ abstract class MCPXeroClient extends XeroClient {
     await this.authenticate();
 
     const organisationResponse = await this.accountingApi.getOrganisations(
-      this.tenantId || "",
+      this.tenantId || ""
     );
 
     const organisation = organisationResponse.body.organisations?.[0];
@@ -66,7 +116,7 @@ abstract class MCPXeroClient extends XeroClient {
         const err = ensureError(error);
 
         throw new Error(
-          `Failed to get Organisation short code: ${err.message}`,
+          `Failed to get Organisation short code: ${err.message}`
         );
       }
     }
@@ -74,6 +124,7 @@ abstract class MCPXeroClient extends XeroClient {
   }
 }
 
+// Custom Connections client (AU/NZ/UK/US only, requires subscription)
 class CustomConnectionsXeroClient extends MCPXeroClient {
   private readonly clientId: string;
   private readonly clientSecret: string;
@@ -92,7 +143,7 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
     const scope =
       "accounting.transactions accounting.contacts accounting.settings accounting.reports.read payroll.settings payroll.employees payroll.timesheets";
     const credentials = Buffer.from(
-      `${this.clientId}:${this.clientSecret}`,
+      `${this.clientId}:${this.clientSecret}`
     ).toString("base64");
 
     try {
@@ -105,10 +156,9 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
             "Content-Type": "application/x-www-form-urlencoded",
             Accept: "application/json",
           },
-        },
+        }
       );
 
-      // Get the tenant ID from the connections endpoint
       const token = response.data.access_token;
       const connectionsResponse = await axios.get(
         "https://api.xero.com/connections",
@@ -117,7 +167,7 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
             Authorization: `Bearer ${token}`,
             Accept: "application/json",
           },
-        },
+        }
       );
 
       if (connectionsResponse.data && connectionsResponse.data.length > 0) {
@@ -128,7 +178,7 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
     } catch (error) {
       const axiosError = error as AxiosError;
       throw new Error(
-        `Failed to get Xero token: ${axiosError.response?.data || axiosError.message}`,
+        `Failed to get Xero token: ${axiosError.response?.data || axiosError.message}`
       );
     }
   }
@@ -144,6 +194,7 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
   }
 }
 
+// Bearer token client (manual token, no refresh)
 class BearerTokenXeroClient extends MCPXeroClient {
   private readonly bearerToken: string;
 
@@ -161,12 +212,312 @@ class BearerTokenXeroClient extends MCPXeroClient {
   }
 }
 
-export const xeroClient = bearer_token
-  ? new BearerTokenXeroClient({
-      bearerToken: bearer_token,
-    })
-  : new CustomConnectionsXeroClient({
-      clientId: client_id!,
-      clientSecret: client_secret!,
-      grantType: grant_type,
+// OAuth Browser client (works everywhere, auto-refresh)
+class OAuthBrowserClient extends MCPXeroClient {
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly scopes: string;
+  private tokens: StoredTokens | null = null;
+
+  constructor(config: {
+    clientId: string;
+    clientSecret: string;
+    scopes: string;
+  }) {
+    super({ clientId: config.clientId, clientSecret: config.clientSecret });
+    this.clientId = config.clientId;
+    this.clientSecret = config.clientSecret;
+    this.scopes = config.scopes;
+  }
+
+  public async authenticate(): Promise<void> {
+    this.tokens = this.loadTokens();
+
+    if (this.tokens) {
+      const now = Date.now();
+      const expiresAt = this.tokens.expires_at;
+      const refreshThreshold = 5 * 60 * 1000; // 5 minutes
+
+      if (expiresAt - now < refreshThreshold) {
+        console.error("Token expiring soon, refreshing...");
+        await this.refreshAccessToken();
+      }
+    } else {
+      console.error(
+        "No valid tokens found, starting browser authentication..."
+      );
+      await this.browserAuth();
+    }
+
+    this.setTokenSet({
+      access_token: this.tokens!.access_token,
+      refresh_token: this.tokens!.refresh_token,
+      id_token: this.tokens!.id_token,
     });
+
+    await this.updateTenants();
+  }
+
+  private async browserAuth(): Promise<void> {
+    const codeVerifier = generateCodeVerifier();
+    const codeChallenge = generateCodeChallenge(codeVerifier);
+    const state = generateState();
+
+    const authParams = new URLSearchParams({
+      response_type: "code",
+      client_id: this.clientId,
+      redirect_uri: REDIRECT_URI,
+      scope: `openid profile email offline_access ${this.scopes}`,
+      state: state,
+      code_challenge: codeChallenge,
+      code_challenge_method: "S256",
+    });
+
+    const authUrl = `${AUTHORIZE_URL}?${authParams.toString()}`;
+
+    console.error("Opening browser for Xero authentication...");
+    console.error(`If browser doesn't open, visit: ${authUrl}`);
+
+    const callbackPromise = this.waitForCallback(state, codeVerifier);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await open(authUrl);
+
+    await callbackPromise;
+  }
+
+  private waitForCallback(
+    expectedState: string,
+    codeVerifier: string
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const server = createServer(
+        async (req: IncomingMessage, res: ServerResponse) => {
+          const url = new URL(
+            req.url || "",
+            `http://localhost:${CALLBACK_PORT}`
+          );
+
+          if (url.pathname !== CALLBACK_PATH) {
+            res.writeHead(404);
+            res.end("Not found");
+            return;
+          }
+
+          const code = url.searchParams.get("code");
+          const state = url.searchParams.get("state");
+          const error = url.searchParams.get("error");
+
+          if (error) {
+            res.writeHead(400);
+            res.end(`Authentication failed: ${error}`);
+            server.close();
+            reject(new Error(`OAuth error: ${error}`));
+            return;
+          }
+
+          if (state !== expectedState) {
+            res.writeHead(400);
+            res.end("Invalid state parameter");
+            server.close();
+            reject(new Error("Invalid state parameter - possible CSRF attack"));
+            return;
+          }
+
+          if (!code) {
+            res.writeHead(400);
+            res.end("No authorization code received");
+            server.close();
+            reject(new Error("No authorization code received"));
+            return;
+          }
+
+          try {
+            await this.exchangeCodeForTokens(code, codeVerifier);
+
+            res.writeHead(200, { "Content-Type": "text/html" });
+            res.end(`
+              <!DOCTYPE html>
+              <html>
+                <head><title>Xero MCP Authentication</title></head>
+                <body style="font-family: system-ui; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;">
+                  <div style="text-align: center;">
+                    <h1 style="color: #13B5EA;">Authentication Successful</h1>
+                    <p>You can close this window and return to your terminal.</p>
+                  </div>
+                </body>
+              </html>
+            `);
+
+            server.close();
+            resolve();
+          } catch (err) {
+            res.writeHead(500);
+            res.end("Failed to exchange token");
+            server.close();
+            reject(err);
+          }
+        }
+      );
+
+      server.listen(CALLBACK_PORT, () => {
+        console.error(`Callback server listening on port ${CALLBACK_PORT}`);
+      });
+
+      setTimeout(() => {
+        server.close();
+        reject(new Error("Authentication timed out after 5 minutes"));
+      }, 5 * 60 * 1000);
+    });
+  }
+
+  private async exchangeCodeForTokens(
+    code: string,
+    codeVerifier: string
+  ): Promise<void> {
+    const credentials = Buffer.from(
+      `${this.clientId}:${this.clientSecret}`
+    ).toString("base64");
+
+    try {
+      const response = await axios.post(
+        TOKEN_URL,
+        new URLSearchParams({
+          grant_type: "authorization_code",
+          code: code,
+          redirect_uri: REDIRECT_URI,
+          code_verifier: codeVerifier,
+        }).toString(),
+        {
+          headers: {
+            Authorization: `Basic ${credentials}`,
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        }
+      );
+
+      const { access_token, refresh_token, expires_in, id_token, scope } =
+        response.data;
+
+      this.tokens = {
+        access_token,
+        refresh_token,
+        expires_at: Date.now() + expires_in * 1000,
+        id_token,
+        scope,
+      };
+
+      this.saveTokens(this.tokens);
+      console.error("Authentication successful, tokens saved.");
+    } catch (error) {
+      const err = ensureError(error);
+      throw new Error(`Failed to exchange code for tokens: ${err.message}`);
+    }
+  }
+
+  private async refreshAccessToken(): Promise<void> {
+    if (!this.tokens?.refresh_token) {
+      throw new Error("No refresh token available");
+    }
+
+    const credentials = Buffer.from(
+      `${this.clientId}:${this.clientSecret}`
+    ).toString("base64");
+
+    try {
+      const response = await axios.post(
+        TOKEN_URL,
+        new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: this.tokens.refresh_token,
+        }).toString(),
+        {
+          headers: {
+            Authorization: `Basic ${credentials}`,
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        }
+      );
+
+      const { access_token, refresh_token, expires_in, id_token, scope } =
+        response.data;
+
+      this.tokens = {
+        access_token,
+        refresh_token: refresh_token || this.tokens.refresh_token,
+        expires_at: Date.now() + expires_in * 1000,
+        id_token,
+        scope,
+      };
+
+      this.saveTokens(this.tokens);
+      console.error("Token refreshed successfully.");
+    } catch (error) {
+      const err = ensureError(error);
+      console.error(`Failed to refresh token: ${err.message}`);
+      this.deleteTokens();
+      this.tokens = null;
+      await this.browserAuth();
+    }
+  }
+
+  private loadTokens(): StoredTokens | null {
+    try {
+      if (fs.existsSync(TOKEN_FILE)) {
+        const data = fs.readFileSync(TOKEN_FILE, "utf-8");
+        return JSON.parse(data) as StoredTokens;
+      }
+    } catch (error) {
+      console.error("Failed to load tokens:", error);
+    }
+    return null;
+  }
+
+  private saveTokens(tokens: StoredTokens): void {
+    try {
+      fs.writeFileSync(TOKEN_FILE, JSON.stringify(tokens, null, 2), {
+        mode: 0o600,
+      });
+    } catch (error) {
+      console.error("Failed to save tokens:", error);
+    }
+  }
+
+  private deleteTokens(): void {
+    try {
+      if (fs.existsSync(TOKEN_FILE)) {
+        fs.unlinkSync(TOKEN_FILE);
+      }
+    } catch (error) {
+      console.error("Failed to delete tokens:", error);
+    }
+  }
+}
+
+// Select client based on environment configuration
+function createXeroClient(): MCPXeroClient {
+  if (use_browser_auth && client_id && client_secret) {
+    console.error("Using OAuth browser authentication");
+    return new OAuthBrowserClient({
+      clientId: client_id,
+      clientSecret: client_secret,
+      scopes: scopes,
+    });
+  }
+
+  if (bearer_token) {
+    console.error("Using bearer token authentication");
+    return new BearerTokenXeroClient({
+      bearerToken: bearer_token,
+    });
+  }
+
+  console.error("Using custom connections authentication");
+  return new CustomConnectionsXeroClient({
+    clientId: client_id!,
+    clientSecret: client_secret!,
+    grantType: grant_type,
+  });
+}
+
+export const xeroClient = createXeroClient();


### PR DESCRIPTION
## Summary

- Adds browser-based OAuth with PKCE that works in **all regions** (not just AU/NZ/UK/US)
- Automatic token refresh - no manual token management needed
- Tokens persisted to `~/.xero-mcp-tokens.json` for seamless subsequent runs

## Why This Change?

The current authentication options have limitations:
1. **Custom Connections** - Requires paid subscription ($5/month), only available in AU/NZ/UK/US
2. **Bearer Token** - Expires after 30 minutes with no automatic refresh

This PR adds a third option that works everywhere with automatic token management.

## Test plan

- [ ] Set `XERO_USE_BROWSER_AUTH=true` with client ID and secret
- [ ] First run should open browser for Xero login
- [ ] After authorization, tokens should be saved
- [ ] Subsequent runs should use saved tokens without browser prompt
- [ ] Token refresh should happen automatically before expiry

🤖 Generated with [Claude Code](https://claude.ai/code)