### PR TITLE
feat: add purchase order tools (create, get, list, update)

### DIFF
--- a/src/consts/deeplinks.ts
+++ b/src/consts/deeplinks.ts
@@ -32,3 +32,7 @@ export const manualJournalDeepLink = (journalId: string) => {
 export const billDeepLink = (orgShortCode: string, billId: string) => {
   return `https://go.xero.com/organisationlogin/default.aspx?shortcode=${orgShortCode}&redirecturl=/AccountsPayable/Edit.aspx?InvoiceID=${billId}`;
 };
+
+export const purchaseOrderDeepLink = (orgShortCode: string, purchaseOrderId: string) => {
+  return `https://go.xero.com/organisationlogin/default.aspx?shortcode=${orgShortCode}&redirecturl=/AccountsPayable/PurchaseOrderSummary.aspx?PurchaseOrderID=${purchaseOrderId}`;
+};

--- a/src/handlers/create-xero-purchase-order.handler.ts
+++ b/src/handlers/create-xero-purchase-order.handler.ts
@@ -1,0 +1,105 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { PurchaseOrder, LineItemTracking } from "xero-node";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+interface PurchaseOrderLineItem {
+  description: string;
+  quantity: number;
+  unitAmount: number;
+  accountCode: string;
+  taxType: string;
+  itemCode?: string;
+  tracking?: LineItemTracking[];
+}
+
+async function createPurchaseOrder(
+  contactId: string,
+  lineItems: PurchaseOrderLineItem[],
+  date: string | undefined,
+  deliveryDate: string | undefined,
+  reference: string | undefined,
+  deliveryAddress: string | undefined,
+  attentionTo: string | undefined,
+  telephone: string | undefined,
+  deliveryInstructions: string | undefined,
+  purchaseOrderNumber: string | undefined,
+): Promise<PurchaseOrder | undefined> {
+  await xeroClient.authenticate();
+
+  const purchaseOrder: PurchaseOrder = {
+    contact: {
+      contactID: contactId,
+    },
+    lineItems: lineItems,
+    date: date || new Date().toISOString().split("T")[0],
+    deliveryDate: deliveryDate,
+    reference: reference,
+    deliveryAddress: deliveryAddress,
+    attentionTo: attentionTo,
+    telephone: telephone,
+    deliveryInstructions: deliveryInstructions,
+    purchaseOrderNumber: purchaseOrderNumber,
+    status: PurchaseOrder.StatusEnum.DRAFT,
+  };
+
+  const response = await xeroClient.accountingApi.createPurchaseOrders(
+    xeroClient.tenantId,
+    {
+      purchaseOrders: [purchaseOrder],
+    },
+    true, // summarizeErrors
+    undefined, // idempotencyKey
+    getClientHeaders(),
+  );
+  const createdPurchaseOrder = response.body.purchaseOrders?.[0];
+  return createdPurchaseOrder;
+}
+
+/**
+ * Create a new purchase order in Xero
+ */
+export async function createXeroPurchaseOrder(
+  contactId: string,
+  lineItems: PurchaseOrderLineItem[],
+  date?: string,
+  deliveryDate?: string,
+  reference?: string,
+  deliveryAddress?: string,
+  attentionTo?: string,
+  telephone?: string,
+  deliveryInstructions?: string,
+  purchaseOrderNumber?: string,
+): Promise<XeroClientResponse<PurchaseOrder>> {
+  try {
+    const createdPurchaseOrder = await createPurchaseOrder(
+      contactId,
+      lineItems,
+      date,
+      deliveryDate,
+      reference,
+      deliveryAddress,
+      attentionTo,
+      telephone,
+      deliveryInstructions,
+      purchaseOrderNumber,
+    );
+
+    if (!createdPurchaseOrder) {
+      throw new Error("Purchase order creation failed.");
+    }
+
+    return {
+      result: createdPurchaseOrder,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/get-xero-purchase-order.handler.ts
+++ b/src/handlers/get-xero-purchase-order.handler.ts
@@ -1,0 +1,67 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { PurchaseOrder } from "xero-node";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+async function getPurchaseOrderById(
+  purchaseOrderId: string,
+): Promise<PurchaseOrder | undefined> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getPurchaseOrder(
+    xeroClient.tenantId,
+    purchaseOrderId,
+    getClientHeaders(),
+  );
+  return response.body.purchaseOrders?.[0];
+}
+
+async function getPurchaseOrderByNumber(
+  purchaseOrderNumber: string,
+): Promise<PurchaseOrder | undefined> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getPurchaseOrderByNumber(
+    xeroClient.tenantId,
+    purchaseOrderNumber,
+    getClientHeaders(),
+  );
+  return response.body.purchaseOrders?.[0];
+}
+
+/**
+ * Get a single purchase order from Xero by ID or number
+ */
+export async function getXeroPurchaseOrder(
+  purchaseOrderId?: string,
+  purchaseOrderNumber?: string,
+): Promise<XeroClientResponse<PurchaseOrder>> {
+  try {
+    let purchaseOrder: PurchaseOrder | undefined;
+
+    if (purchaseOrderId) {
+      purchaseOrder = await getPurchaseOrderById(purchaseOrderId);
+    } else if (purchaseOrderNumber) {
+      purchaseOrder = await getPurchaseOrderByNumber(purchaseOrderNumber);
+    } else {
+      throw new Error("Either purchaseOrderId or purchaseOrderNumber must be provided.");
+    }
+
+    if (!purchaseOrder) {
+      throw new Error("Purchase order not found.");
+    }
+
+    return {
+      result: purchaseOrder,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-purchase-orders.handler.ts
+++ b/src/handlers/list-xero-purchase-orders.handler.ts
@@ -1,0 +1,55 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { PurchaseOrder } from "xero-node";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+async function getPurchaseOrders(
+  page: number,
+  status: PurchaseOrder.StatusEnum | undefined,
+  dateFrom: string | undefined,
+  dateTo: string | undefined,
+): Promise<PurchaseOrder[]> {
+  await xeroClient.authenticate();
+
+  const statusString = status ? status.toString() : undefined;
+
+  const purchaseOrders = await xeroClient.accountingApi.getPurchaseOrders(
+    xeroClient.tenantId,
+    undefined, // ifModifiedSince
+    statusString as 'DRAFT' | 'SUBMITTED' | 'AUTHORISED' | 'BILLED' | 'DELETED' | undefined,
+    dateFrom,
+    dateTo,
+    "UpdatedDateUTC DESC", // order
+    page,
+    10, // pageSize
+    getClientHeaders(),
+  );
+  return purchaseOrders.body.purchaseOrders ?? [];
+}
+
+/**
+ * List all purchase orders from Xero
+ */
+export async function listXeroPurchaseOrders(
+  page: number = 1,
+  status?: PurchaseOrder.StatusEnum,
+  dateFrom?: string,
+  dateTo?: string,
+): Promise<XeroClientResponse<PurchaseOrder[]>> {
+  try {
+    const purchaseOrders = await getPurchaseOrders(page, status, dateFrom, dateTo);
+
+    return {
+      result: purchaseOrders,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/update-xero-purchase-order.handler.ts
+++ b/src/handlers/update-xero-purchase-order.handler.ts
@@ -1,0 +1,128 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { PurchaseOrder, LineItemTracking } from "xero-node";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+interface PurchaseOrderLineItem {
+  lineItemID?: string;
+  description: string;
+  quantity: number;
+  unitAmount: number;
+  accountCode: string;
+  taxType: string;
+  itemCode?: string;
+  tracking?: LineItemTracking[];
+}
+
+async function updatePurchaseOrder(
+  purchaseOrderId: string,
+  contactId: string | undefined,
+  lineItems: PurchaseOrderLineItem[] | undefined,
+  date: string | undefined,
+  deliveryDate: string | undefined,
+  reference: string | undefined,
+  deliveryAddress: string | undefined,
+  attentionTo: string | undefined,
+  telephone: string | undefined,
+  deliveryInstructions: string | undefined,
+  status: PurchaseOrder.StatusEnum | undefined,
+): Promise<PurchaseOrder | undefined> {
+  await xeroClient.authenticate();
+
+  const purchaseOrder: PurchaseOrder = {
+    purchaseOrderID: purchaseOrderId,
+  };
+
+  if (contactId) {
+    purchaseOrder.contact = { contactID: contactId };
+  }
+  if (lineItems) {
+    purchaseOrder.lineItems = lineItems;
+  }
+  if (date) {
+    purchaseOrder.date = date;
+  }
+  if (deliveryDate) {
+    purchaseOrder.deliveryDate = deliveryDate;
+  }
+  if (reference !== undefined) {
+    purchaseOrder.reference = reference;
+  }
+  if (deliveryAddress !== undefined) {
+    purchaseOrder.deliveryAddress = deliveryAddress;
+  }
+  if (attentionTo !== undefined) {
+    purchaseOrder.attentionTo = attentionTo;
+  }
+  if (telephone !== undefined) {
+    purchaseOrder.telephone = telephone;
+  }
+  if (deliveryInstructions !== undefined) {
+    purchaseOrder.deliveryInstructions = deliveryInstructions;
+  }
+  if (status) {
+    purchaseOrder.status = status;
+  }
+
+  const response = await xeroClient.accountingApi.updatePurchaseOrder(
+    xeroClient.tenantId,
+    purchaseOrderId,
+    {
+      purchaseOrders: [purchaseOrder],
+    },
+    undefined, // idempotencyKey
+    getClientHeaders(),
+  );
+  const updatedPurchaseOrder = response.body.purchaseOrders?.[0];
+  return updatedPurchaseOrder;
+}
+
+/**
+ * Update an existing purchase order in Xero
+ */
+export async function updateXeroPurchaseOrder(
+  purchaseOrderId: string,
+  contactId?: string,
+  lineItems?: PurchaseOrderLineItem[],
+  date?: string,
+  deliveryDate?: string,
+  reference?: string,
+  deliveryAddress?: string,
+  attentionTo?: string,
+  telephone?: string,
+  deliveryInstructions?: string,
+  status?: PurchaseOrder.StatusEnum,
+): Promise<XeroClientResponse<PurchaseOrder>> {
+  try {
+    const updatedPurchaseOrder = await updatePurchaseOrder(
+      purchaseOrderId,
+      contactId,
+      lineItems,
+      date,
+      deliveryDate,
+      reference,
+      deliveryAddress,
+      attentionTo,
+      telephone,
+      deliveryInstructions,
+      status,
+    );
+
+    if (!updatedPurchaseOrder) {
+      throw new Error("Purchase order update failed.");
+    }
+
+    return {
+      result: updatedPurchaseOrder,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/helpers/get-deeplink.ts
+++ b/src/helpers/get-deeplink.ts
@@ -7,6 +7,7 @@ import {
   manualJournalDeepLink,
   quoteDeepLink,
   billDeepLink,
+  purchaseOrderDeepLink,
 } from "../consts/deeplinks.js";
 
 export enum DeepLinkType {
@@ -17,6 +18,7 @@ export enum DeepLinkType {
   QUOTE,
   PAYMENT,
   BILL,
+  PURCHASE_ORDER,
 }
 
 /**
@@ -48,5 +50,7 @@ export const getDeepLink = async (type: DeepLinkType, itemId: string) => {
       return paymentDeepLink(orgShortCode, itemId);
     case DeepLinkType.BILL:
       return billDeepLink(orgShortCode, itemId);
+    case DeepLinkType.PURCHASE_ORDER:
+      return purchaseOrderDeepLink(orgShortCode, itemId);
   }
 };

--- a/src/tools/create/create-purchase-order.tool.ts
+++ b/src/tools/create/create-purchase-order.tool.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import { createXeroPurchaseOrder } from "../../handlers/create-xero-purchase-order.handler.js";
+import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const trackingSchema = z.object({
+  name: z.string().describe("The name of the tracking category. Can be obtained from the list-tracking-categories tool"),
+  option: z.string().describe("The name of the tracking option. Can be obtained from the list-tracking-categories tool"),
+  trackingCategoryID: z.string().describe("The ID of the tracking category. \
+    Can be obtained from the list-tracking-categories tool"),
+});
+
+const lineItemSchema = z.object({
+  description: z.string().describe("The description of the line item"),
+  quantity: z.number().describe("The quantity of the line item"),
+  unitAmount: z.number().describe("The price per unit of the line item"),
+  accountCode: z.string().describe("The account code of the line item - can be obtained from the list-accounts tool"),
+  taxType: z.string().describe("The tax type of the line item - can be obtained from the list-tax-rates tool"),
+  itemCode: z.string().describe("The item code of the line item - can be obtained from the list-items tool. \
+    If the item is not listed, add without an item code and ask the user if they would like to add an item code.").optional(),
+  tracking: z.array(trackingSchema).describe("Up to 2 tracking categories and options can be added to the line item. \
+    Can be obtained from the list-tracking-categories tool. \
+    Only use if prompted by the user.").optional(),
+});
+
+const CreatePurchaseOrderTool = CreateXeroTool(
+  "create-purchase-order",
+  "Create a purchase order in Xero. \
+  When a purchase order is created, a deep link to the purchase order in Xero is returned. \
+  This deep link can be used to view the purchase order in Xero directly. \
+  This link should be displayed to the user.",
+  {
+    contactId: z.string().describe("The ID of the contact (supplier) to create the purchase order for. \
+      Can be obtained from the list-contacts tool."),
+    lineItems: z.array(lineItemSchema),
+    date: z.string().describe("The date the purchase order was issued (YYYY-MM-DD format). \
+      Defaults to today if not specified.").optional(),
+    deliveryDate: z.string().describe("The date the goods are to be delivered (YYYY-MM-DD format).").optional(),
+    reference: z.string().describe("An additional reference number for the purchase order.").optional(),
+    deliveryAddress: z.string().describe("The address the goods are to be delivered to.").optional(),
+    attentionTo: z.string().describe("The person that the delivery is going to.").optional(),
+    telephone: z.string().describe("The phone number for the person accepting the delivery.").optional(),
+    deliveryInstructions: z.string().describe("Instructions for delivery (500 characters max).").optional(),
+    purchaseOrderNumber: z.string().describe("Unique alpha numeric code identifying purchase order. \
+      Will auto-generate from Organisation Invoice Settings if not specified.").optional(),
+  },
+  async ({ contactId, lineItems, date, deliveryDate, reference, deliveryAddress, attentionTo, telephone, deliveryInstructions, purchaseOrderNumber }) => {
+    const result = await createXeroPurchaseOrder(
+      contactId,
+      lineItems,
+      date,
+      deliveryDate,
+      reference,
+      deliveryAddress,
+      attentionTo,
+      telephone,
+      deliveryInstructions,
+      purchaseOrderNumber,
+    );
+
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error creating purchase order: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    const purchaseOrder = result.result;
+
+    const deepLink = purchaseOrder.purchaseOrderID
+      ? await getDeepLink(DeepLinkType.PURCHASE_ORDER, purchaseOrder.purchaseOrderID)
+      : null;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Purchase order created successfully:",
+            `ID: ${purchaseOrder?.purchaseOrderID}`,
+            `Number: ${purchaseOrder?.purchaseOrderNumber}`,
+            `Contact: ${purchaseOrder?.contact?.name}`,
+            `Date: ${purchaseOrder?.date}`,
+            purchaseOrder?.deliveryDate ? `Delivery Date: ${purchaseOrder.deliveryDate}` : null,
+            `Total: ${purchaseOrder?.total}`,
+            `Status: ${purchaseOrder?.status}`,
+            deepLink ? `Link to view: ${deepLink}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default CreatePurchaseOrderTool;

--- a/src/tools/create/index.ts
+++ b/src/tools/create/index.ts
@@ -6,6 +6,7 @@ import CreateItemTool from "./create-item.tool.js";
 import CreateManualJournalTool from "./create-manual-journal.tool.js";
 import CreatePaymentTool from "./create-payment.tool.js";
 import CreatePayrollTimesheetTool from "./create-payroll-timesheet.tool.js";
+import CreatePurchaseOrderTool from "./create-purchase-order.tool.js";
 import CreateQuoteTool from "./create-quote.tool.js";
 import CreateTrackingCategoryTool from "./create-tracking-category.tool.js";
 import CreateTrackingOptionsTool from "./create-tracking-options.tool.js";
@@ -15,6 +16,7 @@ export const CreateTools = [
   CreateCreditNoteTool,
   CreateManualJournalTool,
   CreateInvoiceTool,
+  CreatePurchaseOrderTool,
   CreateQuoteTool,
   CreatePaymentTool,
   CreateItemTool,

--- a/src/tools/get/get-purchase-order.tool.ts
+++ b/src/tools/get/get-purchase-order.tool.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import { getXeroPurchaseOrder } from "../../handlers/get-xero-purchase-order.handler.js";
+import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatLineItem } from "../../helpers/format-line-item.js";
+
+const GetPurchaseOrderTool = CreateXeroTool(
+  "get-purchase-order",
+  "Get a single purchase order from Xero by its ID or purchase order number. \
+  This returns full details including line items. \
+  When a purchase order is retrieved, a deep link to the purchase order in Xero is returned. \
+  This deep link can be used to view the purchase order in Xero directly. \
+  This link should be displayed to the user.",
+  {
+    purchaseOrderId: z.string().describe("The unique ID of the purchase order.").optional(),
+    purchaseOrderNumber: z.string().describe("The purchase order number.").optional(),
+  },
+  async ({ purchaseOrderId, purchaseOrderNumber }) => {
+    if (!purchaseOrderId && !purchaseOrderNumber) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "Error: Either purchaseOrderId or purchaseOrderNumber must be provided.",
+          },
+        ],
+      };
+    }
+
+    const result = await getXeroPurchaseOrder(purchaseOrderId, purchaseOrderNumber);
+
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error getting purchase order: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    const po = result.result;
+
+    const deepLink = po.purchaseOrderID
+      ? await getDeepLink(DeepLinkType.PURCHASE_ORDER, po.purchaseOrderID)
+      : null;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Purchase Order Details:",
+            `ID: ${po.purchaseOrderID}`,
+            `Number: ${po.purchaseOrderNumber}`,
+            po.reference ? `Reference: ${po.reference}` : null,
+            `Status: ${po.status || "Unknown"}`,
+            po.contact
+              ? `Contact: ${po.contact.name} (${po.contact.contactID})`
+              : null,
+            po.date ? `Date: ${po.date}` : null,
+            po.deliveryDate ? `Delivery Date: ${po.deliveryDate}` : null,
+            po.expectedArrivalDate ? `Expected Arrival: ${po.expectedArrivalDate}` : null,
+            po.deliveryAddress ? `Delivery Address: ${po.deliveryAddress}` : null,
+            po.attentionTo ? `Attention To: ${po.attentionTo}` : null,
+            po.telephone ? `Telephone: ${po.telephone}` : null,
+            po.deliveryInstructions ? `Delivery Instructions: ${po.deliveryInstructions}` : null,
+            po.lineAmountTypes
+              ? `Line Amount Types: ${po.lineAmountTypes}`
+              : null,
+            po.subTotal !== undefined ? `Sub Total: ${po.subTotal}` : null,
+            po.totalTax !== undefined ? `Total Tax: ${po.totalTax}` : null,
+            `Total: ${po.total || 0}`,
+            po.totalDiscount
+              ? `Total Discount: ${po.totalDiscount}`
+              : null,
+            po.currencyCode ? `Currency: ${po.currencyCode}` : null,
+            po.currencyRate
+              ? `Currency Rate: ${po.currencyRate}`
+              : null,
+            po.brandingThemeID ? `Branding Theme ID: ${po.brandingThemeID}` : null,
+            po.updatedDateUTC
+              ? `Last Updated: ${po.updatedDateUTC}`
+              : null,
+            po.sentToContact ? "Sent to Contact: Yes" : null,
+            po.hasAttachments ? "Has Attachments: Yes" : null,
+            po.lineItems && po.lineItems.length > 0
+              ? `Line Items:\n${po.lineItems.map(formatLineItem).join("\n")}`
+              : null,
+            deepLink ? `Link to view: ${deepLink}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default GetPurchaseOrderTool;

--- a/src/tools/get/index.ts
+++ b/src/tools/get/index.ts
@@ -1,5 +1,7 @@
 import GetPayrollTimesheetTool from "./get-payroll-timesheet.tool.js";
+import GetPurchaseOrderTool from "./get-purchase-order.tool.js";
 
 export const GetTools = [
   GetPayrollTimesheetTool,
+  GetPurchaseOrderTool,
 ];

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -22,6 +22,7 @@ import ListPayrollLeavePeriodsToolTool
 import ListPayrollLeaveTypesTool from "./list-payroll-leave-types.tool.js";
 import ListPayrollTimesheetsTool from "./list-payroll-timesheets.tool.js";
 import ListProfitAndLossTool from "./list-profit-and-loss.tool.js";
+import ListPurchaseOrdersTool from "./list-purchase-orders.tool.js";
 import ListQuotesTool from "./list-quotes.tool.js";
 import ListReportBalanceSheetTool from "./list-report-balance-sheet.tool.js";
 import ListTaxRatesTool from "./list-tax-rates.tool.js";
@@ -36,6 +37,7 @@ export const ListTools = [
   ListInvoicesTool,
   ListItemsTool,
   ListManualJournalsTool,
+  ListPurchaseOrdersTool,
   ListQuotesTool,
   ListTaxRatesTool,
   ListTrialBalanceTool,

--- a/src/tools/list/list-purchase-orders.tool.ts
+++ b/src/tools/list/list-purchase-orders.tool.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import { listXeroPurchaseOrders } from "../../handlers/list-xero-purchase-orders.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatLineItem } from "../../helpers/format-line-item.js";
+import { PurchaseOrder } from "xero-node";
+
+const ListPurchaseOrdersTool = CreateXeroTool(
+  "list-purchase-orders",
+  "List purchase orders in Xero. This includes Draft, Submitted, Authorised, and Billed purchase orders. \
+  Ask the user if they want to filter by status or date range before running. \
+  Ask the user if they want the next page of purchase orders after running this tool \
+  if 10 purchase orders are returned. \
+  If they want the next page, call this tool again with the next page number \
+  and the same filters if any were provided in the previous call.",
+  {
+    page: z.number().describe("The page number to retrieve (starts at 1)."),
+    status: z.enum(["DRAFT", "SUBMITTED", "AUTHORISED", "BILLED", "DELETED"])
+      .describe("Filter by purchase order status.").optional(),
+    dateFrom: z.string().describe("Filter by purchase orders on or after this date (YYYY-MM-DD format).").optional(),
+    dateTo: z.string().describe("Filter by purchase orders on or before this date (YYYY-MM-DD format).").optional(),
+  },
+  async ({ page, status, dateFrom, dateTo }) => {
+    const statusEnum = status ? PurchaseOrder.StatusEnum[status as keyof typeof PurchaseOrder.StatusEnum] : undefined;
+
+    const response = await listXeroPurchaseOrders(page, statusEnum, dateFrom, dateTo);
+
+    if (response.error !== null) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing purchase orders: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const purchaseOrders = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${purchaseOrders?.length || 0} purchase orders:`,
+        },
+        ...(purchaseOrders?.map((po) => ({
+          type: "text" as const,
+          text: [
+            `Purchase Order ID: ${po.purchaseOrderID}`,
+            `Number: ${po.purchaseOrderNumber}`,
+            po.reference ? `Reference: ${po.reference}` : null,
+            `Status: ${po.status || "Unknown"}`,
+            po.contact
+              ? `Contact: ${po.contact.name} (${po.contact.contactID})`
+              : null,
+            po.date ? `Date: ${po.date}` : null,
+            po.deliveryDate ? `Delivery Date: ${po.deliveryDate}` : null,
+            po.deliveryAddress ? `Delivery Address: ${po.deliveryAddress}` : null,
+            po.attentionTo ? `Attention To: ${po.attentionTo}` : null,
+            po.lineAmountTypes
+              ? `Line Amount Types: ${po.lineAmountTypes}`
+              : null,
+            po.subTotal !== undefined ? `Sub Total: ${po.subTotal}` : null,
+            po.totalTax !== undefined ? `Total Tax: ${po.totalTax}` : null,
+            `Total: ${po.total || 0}`,
+            po.totalDiscount
+              ? `Total Discount: ${po.totalDiscount}`
+              : null,
+            po.currencyCode ? `Currency: ${po.currencyCode}` : null,
+            po.currencyRate
+              ? `Currency Rate: ${po.currencyRate}`
+              : null,
+            po.updatedDateUTC
+              ? `Last Updated: ${po.updatedDateUTC}`
+              : null,
+            po.sentToContact ? "Sent to Contact: Yes" : null,
+            po.hasAttachments ? "Has Attachments: Yes" : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPurchaseOrdersTool;

--- a/src/tools/update/index.ts
+++ b/src/tools/update/index.ts
@@ -9,6 +9,7 @@ import AddTimesheetLineTool from "./update-payroll-timesheet-add-line.tool.js";
 import UpdatePayrollTimesheetLineTool
   from "./update-payroll-timesheet-update-line.tool.js";
 import UpdateManualJournalTool from "./update-manual-journal-tool.js";
+import UpdatePurchaseOrderTool from "./update-purchase-order.tool.js";
 import UpdateQuoteTool from "./update-quote.tool.js";
 import UpdateTrackingCategoryTool from "./update-tracking-category.tool.js";
 import UpdateTrackingOptionsTool from "./update-tracking-options.tool.js";
@@ -18,6 +19,7 @@ export const UpdateTools = [
   UpdateCreditNoteTool,
   UpdateInvoiceTool,
   UpdateManualJournalTool,
+  UpdatePurchaseOrderTool,
   UpdateQuoteTool,
   UpdateItemTool,
   UpdateBankTransactionTool,

--- a/src/tools/update/update-purchase-order.tool.ts
+++ b/src/tools/update/update-purchase-order.tool.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import { updateXeroPurchaseOrder } from "../../handlers/update-xero-purchase-order.handler.js";
+import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { PurchaseOrder } from "xero-node";
+
+const trackingSchema = z.object({
+  name: z.string().describe("The name of the tracking category. Can be obtained from the list-tracking-categories tool"),
+  option: z.string().describe("The name of the tracking option. Can be obtained from the list-tracking-categories tool"),
+  trackingCategoryID: z.string().describe("The ID of the tracking category. \
+    Can be obtained from the list-tracking-categories tool"),
+});
+
+const lineItemSchema = z.object({
+  lineItemID: z.string().describe("The ID of an existing line item to update. \
+    Required when updating existing line items.").optional(),
+  description: z.string().describe("The description of the line item"),
+  quantity: z.number().describe("The quantity of the line item"),
+  unitAmount: z.number().describe("The price per unit of the line item"),
+  accountCode: z.string().describe("The account code of the line item - can be obtained from the list-accounts tool"),
+  taxType: z.string().describe("The tax type of the line item - can be obtained from the list-tax-rates tool"),
+  itemCode: z.string().describe("The item code of the line item - can be obtained from the list-items tool.").optional(),
+  tracking: z.array(trackingSchema).describe("Up to 2 tracking categories and options can be added to the line item. \
+    Can be obtained from the list-tracking-categories tool. \
+    Only use if prompted by the user.").optional(),
+});
+
+const UpdatePurchaseOrderTool = CreateXeroTool(
+  "update-purchase-order",
+  "Update an existing purchase order in Xero. Only works on draft purchase orders. \
+  All line items must be provided when updating. Any line items not provided will be removed. \
+  Do not modify line items that have not been specified by the user. \
+  When a purchase order is updated, a deep link to the purchase order in Xero is returned. \
+  This deep link can be used to view the purchase order in Xero directly. \
+  This link should be displayed to the user.",
+  {
+    purchaseOrderId: z.string().describe("The unique ID of the purchase order to update."),
+    contactId: z.string().describe("The ID of the contact (supplier) for the purchase order. \
+      Can be obtained from the list-contacts tool.").optional(),
+    lineItems: z.array(lineItemSchema).describe("All line items for the purchase order. \
+      Any existing line items not included will be removed.").optional(),
+    date: z.string().describe("The date the purchase order was issued (YYYY-MM-DD format).").optional(),
+    deliveryDate: z.string().describe("The date the goods are to be delivered (YYYY-MM-DD format).").optional(),
+    reference: z.string().describe("An additional reference number for the purchase order.").optional(),
+    deliveryAddress: z.string().describe("The address the goods are to be delivered to.").optional(),
+    attentionTo: z.string().describe("The person that the delivery is going to.").optional(),
+    telephone: z.string().describe("The phone number for the person accepting the delivery.").optional(),
+    deliveryInstructions: z.string().describe("Instructions for delivery (500 characters max).").optional(),
+    status: z.enum(["DRAFT", "SUBMITTED", "AUTHORISED", "BILLED", "DELETED"])
+      .describe("The status to set for the purchase order.").optional(),
+  },
+  async ({ purchaseOrderId, contactId, lineItems, date, deliveryDate, reference, deliveryAddress, attentionTo, telephone, deliveryInstructions, status }) => {
+    const statusEnum = status ? PurchaseOrder.StatusEnum[status as keyof typeof PurchaseOrder.StatusEnum] : undefined;
+
+    const result = await updateXeroPurchaseOrder(
+      purchaseOrderId,
+      contactId,
+      lineItems,
+      date,
+      deliveryDate,
+      reference,
+      deliveryAddress,
+      attentionTo,
+      telephone,
+      deliveryInstructions,
+      statusEnum,
+    );
+
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error updating purchase order: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    const purchaseOrder = result.result;
+
+    const deepLink = purchaseOrder.purchaseOrderID
+      ? await getDeepLink(DeepLinkType.PURCHASE_ORDER, purchaseOrder.purchaseOrderID)
+      : null;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Purchase order updated successfully:",
+            `ID: ${purchaseOrder?.purchaseOrderID}`,
+            `Number: ${purchaseOrder?.purchaseOrderNumber}`,
+            `Contact: ${purchaseOrder?.contact?.name}`,
+            `Date: ${purchaseOrder?.date}`,
+            purchaseOrder?.deliveryDate ? `Delivery Date: ${purchaseOrder.deliveryDate}` : null,
+            `Total: ${purchaseOrder?.total}`,
+            `Status: ${purchaseOrder?.status}`,
+            deepLink ? `Link to view: ${deepLink}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default UpdatePurchaseOrderTool;


### PR DESCRIPTION
Add full CRUD support for Xero purchase orders including:
- Create purchase order with line items, delivery details, and tracking
- Get purchase order by ID or PO number
- List purchase orders with status and date filtering
- Update draft purchase orders
- Deep link support for viewing purchase orders in Xero