### PR TITLE
feat: add create account tool for chart of accounts

### DIFF
--- a/src/handlers/create-xero-account.handler.ts
+++ b/src/handlers/create-xero-account.handler.ts
@@ -1,0 +1,89 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { Account, AccountType, CurrencyCode } from "xero-node";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+async function createAccount(
+  code: string,
+  name: string,
+  type: AccountType,
+  description?: string,
+  taxType?: string,
+  enablePaymentsToAccount?: boolean,
+  showInExpenseClaims?: boolean,
+  bankAccountNumber?: string,
+  bankAccountType?: Account.BankAccountTypeEnum,
+  currencyCode?: CurrencyCode,
+): Promise<Account | undefined> {
+  await xeroClient.authenticate();
+
+  const account: Account = {
+    code,
+    name,
+    type,
+    description,
+    taxType,
+    enablePaymentsToAccount,
+    showInExpenseClaims,
+    bankAccountNumber,
+    bankAccountType,
+    currencyCode,
+  };
+
+  const response = await xeroClient.accountingApi.createAccount(
+    xeroClient.tenantId,
+    account,
+    undefined, // idempotencyKey
+    getClientHeaders(),
+  );
+
+  return response.body.accounts?.[0];
+}
+
+/**
+ * Create a new account in Xero
+ */
+export async function createXeroAccount(
+  code: string,
+  name: string,
+  type: AccountType,
+  description?: string,
+  taxType?: string,
+  enablePaymentsToAccount?: boolean,
+  showInExpenseClaims?: boolean,
+  bankAccountNumber?: string,
+  bankAccountType?: Account.BankAccountTypeEnum,
+  currencyCode?: CurrencyCode,
+): Promise<XeroClientResponse<Account>> {
+  try {
+    const createdAccount = await createAccount(
+      code,
+      name,
+      type,
+      description,
+      taxType,
+      enablePaymentsToAccount,
+      showInExpenseClaims,
+      bankAccountNumber,
+      bankAccountType,
+      currencyCode,
+    );
+
+    if (!createdAccount) {
+      throw new Error("Account creation failed.");
+    }
+
+    return {
+      result: createdAccount,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/tools/create/create-account.tool.ts
+++ b/src/tools/create/create-account.tool.ts
@@ -1,0 +1,137 @@
+import { createXeroAccount } from "../../handlers/create-xero-account.handler.js";
+import { z } from "zod";
+import { ensureError } from "../../helpers/ensure-error.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { Account, AccountType, CurrencyCode } from "xero-node";
+
+const accountTypeEnum = z.enum([
+  "BANK",
+  "CURRENT",
+  "CURRLIAB",
+  "DEPRECIATN",
+  "DIRECTCOSTS",
+  "EQUITY",
+  "EXPENSE",
+  "FIXED",
+  "INVENTORY",
+  "LIABILITY",
+  "NONCURRENT",
+  "OTHERINCOME",
+  "OVERHEADS",
+  "PREPAYMENT",
+  "REVENUE",
+  "SALES",
+  "TERMLIAB",
+  "PAYG",
+]);
+
+const bankAccountTypeEnum = z.enum([
+  "BANK",
+  "CREDITCARD",
+  "PAYPAL",
+]);
+
+const CreateAccountTool = CreateXeroTool(
+  "create-account",
+  "Create an account in Xero's chart of accounts. \
+  Use this to add new accounts for tracking revenue, expenses, assets, liabilities, or equity. \
+  When an account is created, details including the account ID are returned.",
+  {
+    code: z.string().describe("A unique code for the account (e.g., '200', '400', '610')"),
+    name: z.string().describe("The name of the account (e.g., 'Sales', 'Office Supplies', 'Bank Account')"),
+    type: accountTypeEnum.describe(
+      "The account type. Common types: REVENUE (income), EXPENSE (costs), BANK (bank accounts), " +
+      "CURRENT (current assets), CURRLIAB (current liabilities), FIXED (fixed assets), " +
+      "EQUITY (owner's equity), DIRECTCOSTS (cost of goods sold), OVERHEADS (operating expenses)"
+    ),
+    description: z.string().optional().describe("A description of the account's purpose"),
+    taxType: z.string().optional().describe("The tax type for the account (e.g., 'OUTPUT', 'INPUT', 'NONE')"),
+    enablePaymentsToAccount: z.boolean().optional().describe("Enable payments to this account (for BANK type accounts)"),
+    showInExpenseClaims: z.boolean().optional().describe("Show this account in expense claims"),
+    bankAccountNumber: z.string().optional().describe("Bank account number (required for BANK type accounts)"),
+    bankAccountType: bankAccountTypeEnum.optional().describe("Type of bank account: BANK, CREDITCARD, or PAYPAL (required for BANK type accounts)"),
+    currencyCode: z.string().optional().describe("Currency code for the account (e.g., 'USD', 'GBP', 'AUD')"),
+  },
+  async ({
+    code,
+    name,
+    type,
+    description,
+    taxType,
+    enablePaymentsToAccount,
+    showInExpenseClaims,
+    bankAccountNumber,
+    bankAccountType,
+    currencyCode,
+  }) => {
+    try {
+      const accountType = AccountType[type as keyof typeof AccountType];
+      const bankAcctType = bankAccountType
+        ? Account.BankAccountTypeEnum[bankAccountType as keyof typeof Account.BankAccountTypeEnum]
+        : undefined;
+      const currency = currencyCode
+        ? CurrencyCode[currencyCode as keyof typeof CurrencyCode]
+        : undefined;
+
+      const response = await createXeroAccount(
+        code,
+        name,
+        accountType,
+        description,
+        taxType,
+        enablePaymentsToAccount,
+        showInExpenseClaims,
+        bankAccountNumber,
+        bankAcctType,
+        currency,
+      );
+
+      if (response.isError) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error creating account: ${response.error}`,
+            },
+          ],
+        };
+      }
+
+      const account = response.result;
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: [
+              `Account created successfully:`,
+              `Name: ${account.name}`,
+              `Code: ${account.code}`,
+              `ID: ${account.accountID}`,
+              `Type: ${account.type}`,
+              `Status: ${account.status}`,
+              account.description ? `Description: ${account.description}` : null,
+              account.taxType ? `Tax Type: ${account.taxType}` : null,
+              account.bankAccountNumber ? `Bank Account Number: ${account.bankAccountNumber}` : null,
+            ]
+              .filter(Boolean)
+              .join("\n"),
+          },
+        ],
+      };
+    } catch (error) {
+      const err = ensureError(error);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error creating account: ${err.message}`,
+          },
+        ],
+      };
+    }
+  },
+);
+
+export default CreateAccountTool;

--- a/src/tools/create/index.ts
+++ b/src/tools/create/index.ts
@@ -1,3 +1,4 @@
+import CreateAccountTool from "./create-account.tool.js";
 import CreateBankTransactionTool from "./create-bank-transaction.tool.js";
 import CreateContactTool from "./create-contact.tool.js";
 import CreateCreditNoteTool from "./create-credit-note.tool.js";
@@ -11,6 +12,7 @@ import CreateTrackingCategoryTool from "./create-tracking-category.tool.js";
 import CreateTrackingOptionsTool from "./create-tracking-options.tool.js";
 
 export const CreateTools = [
+  CreateAccountTool,
   CreateContactTool,
   CreateCreditNoteTool,
   CreateManualJournalTool,


### PR DESCRIPTION
Except for initial importing of a GL account list through MCP, this is dangerous and can destroy your GL.

Add support for creating accounts in Xero's chart of accounts including:
- All account types (BANK, REVENUE, EXPENSE, FIXED, etc.)
- Bank account configuration with account numbers
- Tax type and currency support
- Expense claim visibility option