### PR TITLE
feat: add OAuth2 PKCE authentication with token refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,32 @@
-# Xero API Configuration for Custom Connections
+# Xero API Configuration
+#
+# Choose ONE of the following authentication modes:
+#
+# ============================================
+# MODE 1: OAuth with Auto-Renewal (Recommended)
+# ============================================
+# Use this for standard Xero apps that need user authorization.
+# Run `npm run oauth-setup` first to authorize and get tokens.
+#
+XERO_OAUTH_MODE=true
 XERO_CLIENT_ID=your_client_id_here
-XERO_CLIENT_SECRET=your_client_secret_here 
+XERO_CLIENT_SECRET=your_client_secret_here
+# Optional: Custom path for token storage (defaults to .xero-tokens.json)
+# XERO_TOKEN_FILE=/path/to/.xero-tokens.json
+#
+# ============================================
+# MODE 2: Custom Connections (M2M)
+# ============================================
+# Use this for machine-to-machine integration with a single organization.
+# Requires Custom Connections enabled in Xero Developer Portal.
+# Comment out XERO_OAUTH_MODE and set:
+#
+# XERO_CLIENT_ID=your_client_id_here
+# XERO_CLIENT_SECRET=your_client_secret_here
+#
+# ============================================
+# MODE 3: Bearer Token (Manual)
+# ============================================
+# Use this if you manage tokens externally. Token must be refreshed manually.
+#
+# XERO_CLIENT_BEARER_TOKEN=your_access_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ web_modules/
 .env.production.local
 .env.local
 
+# OAuth tokens (sensitive!)
+.xero-tokens.json
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@xeroapi/xero-mcp-server",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xeroapi/xero-mcp-server",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.4",
         "dotenv": "^16.4.7",
+        "open": "^10.1.0",
         "openid-client": "^6.8.1",
         "xero-node": "^13.3.0",
         "zod": "3.25"
@@ -393,6 +394,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -623,6 +625,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -764,6 +767,21 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bytes": {
@@ -960,6 +978,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1099,6 +1157,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1882,6 +1941,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1905,11 +1979,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2192,6 +2299,24 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openid-client": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.1.tgz",
@@ -2328,6 +2453,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2514,6 +2640,18 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safe-buffer": {
@@ -2877,6 +3015,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2984,6 +3123,21 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xero-node": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/xero-node/-/xero-node-13.3.0.tgz",
@@ -3042,6 +3196,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "lint:fix": "eslint --fix",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "oauth-setup": "node dist/oauth-setup.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.23.4",
     "dotenv": "^16.4.7",
+    "open": "^10.1.0",
     "openid-client": "^6.8.1",
     "xero-node": "^13.3.0",
     "zod": "3.25"

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -8,16 +8,29 @@ import {
 } from "xero-node";
 
 import { ensureError } from "../helpers/ensure-error.js";
+import {
+  loadTokens,
+  saveTokens,
+  isTokenExpired,
+  tokenSetToStored,
+  StoredTokenSet,
+} from "../helpers/token-storage.js";
 
 dotenv.config();
 
 const client_id = process.env.XERO_CLIENT_ID;
 const client_secret = process.env.XERO_CLIENT_SECRET;
 const bearer_token = process.env.XERO_CLIENT_BEARER_TOKEN;
+const oauth_mode = process.env.XERO_OAUTH_MODE === "true";
 const grant_type = "client_credentials";
 
-if (!bearer_token && (!client_id || !client_secret)) {
+// Allow OAuth mode with client_id/secret, or bearer token, or custom connections
+if (!bearer_token && !oauth_mode && (!client_id || !client_secret)) {
   throw Error("Environment Variables not set - please check your .env file");
+}
+
+if (oauth_mode && (!client_id || !client_secret)) {
+  throw Error("XERO_OAUTH_MODE requires XERO_CLIENT_ID and XERO_CLIENT_SECRET");
 }
 
 abstract class MCPXeroClient extends XeroClient {
@@ -127,8 +140,32 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
       return response.data;
     } catch (error) {
       const axiosError = error as AxiosError;
+      const status = axiosError.response?.status;
+      const responseData = axiosError.response?.data;
+
+      console.error("\n========== XERO AUTHENTICATION ERROR ==========");
+      console.error("Error Type: Client Credentials Authentication Failed");
+      console.error(`Status: ${status} ${axiosError.response?.statusText || ""}`);
+      console.error("Response:", JSON.stringify(responseData, null, 2));
+
+      if (status === 401) {
+        console.error("\n[401 Unauthorized] Invalid Client Credentials");
+        console.error("Please verify:");
+        console.error("  1. XERO_CLIENT_ID is correct");
+        console.error("  2. XERO_CLIENT_SECRET is correct");
+        console.error("  3. Your Xero app is configured for Custom Connections");
+      } else if (status === 403) {
+        console.error("\n[403 Forbidden] Insufficient Permissions");
+        console.error("Requested scopes:", scope);
+        console.error("Please verify your app has the required scopes enabled.");
+      } else if (!axiosError.response) {
+        console.error("\n[Network Error] Unable to reach Xero API");
+        console.error("Please check your internet connection and firewall settings.");
+      }
+      console.error("================================================\n");
+
       throw new Error(
-        `Failed to get Xero token: ${axiosError.response?.data || axiosError.message}`,
+        `Failed to get Xero token: ${JSON.stringify(responseData) || axiosError.message}`,
       );
     }
   }
@@ -161,12 +198,139 @@ class BearerTokenXeroClient extends MCPXeroClient {
   }
 }
 
+class OAuthXeroClient extends MCPXeroClient {
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private currentTokens: StoredTokenSet | null = null;
+
+  constructor(config: { clientId: string; clientSecret: string }) {
+    super({ clientId: config.clientId, clientSecret: config.clientSecret });
+    this.clientId = config.clientId;
+    this.clientSecret = config.clientSecret;
+    this.currentTokens = loadTokens();
+  }
+
+  private async refreshAccessToken(): Promise<StoredTokenSet> {
+    if (!this.currentTokens?.refresh_token) {
+      throw new Error(
+        "No refresh token available. Run the OAuth authorization flow first:\n" +
+          "  node dist/oauth-setup.js"
+      );
+    }
+
+    const credentials = Buffer.from(
+      `${this.clientId}:${this.clientSecret}`
+    ).toString("base64");
+
+    try {
+      const response = await axios.post(
+        "https://identity.xero.com/connect/token",
+        `grant_type=refresh_token&refresh_token=${encodeURIComponent(this.currentTokens.refresh_token)}`,
+        {
+          headers: {
+            Authorization: `Basic ${credentials}`,
+            "Content-Type": "application/x-www-form-urlencoded",
+            Accept: "application/json",
+          },
+        }
+      );
+
+      const newTokens: StoredTokenSet = {
+        access_token: response.data.access_token,
+        refresh_token: response.data.refresh_token,
+        expires_at: Date.now() + response.data.expires_in * 1000,
+        token_type: response.data.token_type,
+        scope: response.data.scope,
+      };
+
+      saveTokens(newTokens);
+      this.currentTokens = newTokens;
+
+      console.error("[Xero OAuth] Token refreshed successfully");
+      return newTokens;
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      const status = axiosError.response?.status;
+      const responseData = axiosError.response?.data;
+
+      console.error("\n========== XERO OAUTH ERROR ==========");
+      console.error("Error Type: Token Refresh Failed");
+      console.error(`Status: ${status} ${axiosError.response?.statusText || ""}`);
+      console.error("Response:", JSON.stringify(responseData, null, 2));
+
+      if (status === 400 || status === 401) {
+        console.error("\nThe refresh token may have expired or been revoked.");
+        console.error("Please re-run the OAuth authorization flow:");
+        console.error("  node dist/oauth-setup.js");
+      }
+      console.error("=======================================\n");
+
+      throw new Error(
+        `Failed to refresh Xero token: ${JSON.stringify(responseData) || axiosError.message}`
+      );
+    }
+  }
+
+  async authenticate(): Promise<void> {
+    // Load tokens from storage if not already loaded
+    if (!this.currentTokens) {
+      this.currentTokens = loadTokens();
+    }
+
+    if (!this.currentTokens) {
+      throw new Error(
+        "No OAuth tokens found. Run the OAuth authorization flow first:\n" +
+          "  node dist/oauth-setup.js"
+      );
+    }
+
+    // Refresh if expired or about to expire
+    if (isTokenExpired(this.currentTokens)) {
+      console.error("[Xero OAuth] Token expired, refreshing...");
+      await this.refreshAccessToken();
+    }
+
+    this.setTokenSet({
+      access_token: this.currentTokens.access_token,
+      refresh_token: this.currentTokens.refresh_token,
+      token_type: this.currentTokens.token_type,
+    });
+
+    // Get tenant ID if we don't have it
+    if (!this.tenantId) {
+      try {
+        const connectionsResponse = await axios.get(
+          "https://api.xero.com/connections",
+          {
+            headers: {
+              Authorization: `Bearer ${this.currentTokens.access_token}`,
+              Accept: "application/json",
+            },
+          }
+        );
+
+        if (connectionsResponse.data && connectionsResponse.data.length > 0) {
+          this.tenantId = connectionsResponse.data[0].tenantId;
+        }
+      } catch (error) {
+        const axiosError = error as AxiosError;
+        console.error("Failed to get connections:", axiosError.message);
+      }
+    }
+  }
+}
+
 export const xeroClient = bearer_token
   ? new BearerTokenXeroClient({
       bearerToken: bearer_token,
     })
-  : new CustomConnectionsXeroClient({
-      clientId: client_id!,
-      clientSecret: client_secret!,
-      grantType: grant_type,
-    });
+  : oauth_mode
+    ? new OAuthXeroClient({
+        clientId: client_id!,
+        clientSecret: client_secret!,
+      })
+    : new CustomConnectionsXeroClient({
+        clientId: client_id!,
+        clientSecret: client_secret!,
+        grantType: grant_type,
+      });

--- a/src/helpers/token-storage.ts
+++ b/src/helpers/token-storage.ts
@@ -1,0 +1,45 @@
+import fs from "fs";
+import path from "path";
+import { TokenSet } from "xero-node";
+
+const TOKEN_FILE = process.env.XERO_TOKEN_FILE || path.join(process.cwd(), ".xero-tokens.json");
+
+export interface StoredTokenSet {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number; // Unix timestamp in milliseconds
+  token_type?: string;
+  scope?: string;
+}
+
+export function saveTokens(tokens: StoredTokenSet): void {
+  fs.writeFileSync(TOKEN_FILE, JSON.stringify(tokens, null, 2), "utf-8");
+}
+
+export function loadTokens(): StoredTokenSet | null {
+  try {
+    if (fs.existsSync(TOKEN_FILE)) {
+      const data = fs.readFileSync(TOKEN_FILE, "utf-8");
+      return JSON.parse(data) as StoredTokenSet;
+    }
+  } catch (error) {
+    console.error("Failed to load tokens:", error);
+  }
+  return null;
+}
+
+export function isTokenExpired(tokens: StoredTokenSet): boolean {
+  // Consider token expired 60 seconds before actual expiry for safety margin
+  const safetyMargin = 60 * 1000;
+  return Date.now() >= tokens.expires_at - safetyMargin;
+}
+
+export function tokenSetToStored(tokenSet: TokenSet, expiresIn: number): StoredTokenSet {
+  return {
+    access_token: tokenSet.access_token!,
+    refresh_token: tokenSet.refresh_token!,
+    expires_at: Date.now() + expiresIn * 1000,
+    token_type: tokenSet.token_type,
+    scope: tokenSet.scope,
+  };
+}

--- a/src/oauth-setup.ts
+++ b/src/oauth-setup.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+import http from "http";
+import open from "open";
+import axios from "axios";
+import dotenv from "dotenv";
+import crypto from "crypto";
+import { saveTokens, StoredTokenSet } from "./helpers/token-storage.js";
+
+dotenv.config();
+
+const CLIENT_ID = process.env.XERO_CLIENT_ID;
+const CLIENT_SECRET = process.env.XERO_CLIENT_SECRET;
+const REDIRECT_URI = "http://localhost:5000/callback";
+const SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "accounting.transactions",
+  "accounting.contacts",
+  "accounting.settings",
+  "accounting.reports.read",
+  "payroll.settings",
+  "payroll.employees",
+  "payroll.timesheets",
+  "offline_access", // Required for refresh tokens
+].join(" ");
+
+if (!CLIENT_ID || !CLIENT_SECRET) {
+  console.error("Error: XERO_CLIENT_ID and XERO_CLIENT_SECRET must be set in .env file");
+  process.exit(1);
+}
+
+function generateCodeVerifier(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+function generateCodeChallenge(verifier: string): string {
+  return crypto.createHash("sha256").update(verifier).digest("base64url");
+}
+
+function generateState(): string {
+  return crypto.randomBytes(16).toString("hex");
+}
+
+async function main() {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  const authUrl = new URL("https://login.xero.com/identity/connect/authorize");
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("client_id", CLIENT_ID!);
+  authUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+  authUrl.searchParams.set("scope", SCOPES);
+  authUrl.searchParams.set("state", state);
+  authUrl.searchParams.set("code_challenge", codeChallenge);
+  authUrl.searchParams.set("code_challenge_method", "S256");
+
+  console.log("\n========================================");
+  console.log("  Xero OAuth2 Authorization Setup");
+  console.log("========================================\n");
+  console.log("This will open your browser to authorize the Xero MCP server.");
+  console.log("After authorization, you'll be redirected back here.\n");
+
+  return new Promise<void>((resolve, reject) => {
+    const server = http.createServer(async (req, res) => {
+      const url = new URL(req.url!, `http://localhost:5000`);
+
+      if (url.pathname === "/callback") {
+        const code = url.searchParams.get("code");
+        const returnedState = url.searchParams.get("state");
+        const error = url.searchParams.get("error");
+
+        if (error) {
+          const errorDescription = url.searchParams.get("error_description");
+          res.writeHead(400, { "Content-Type": "text/html" });
+          res.end(`
+            <html>
+              <body style="font-family: sans-serif; padding: 40px;">
+                <h1 style="color: red;">Authorization Failed</h1>
+                <p><strong>Error:</strong> ${error}</p>
+                <p><strong>Description:</strong> ${errorDescription}</p>
+                <p>You can close this window.</p>
+              </body>
+            </html>
+          `);
+          server.close();
+          reject(new Error(`OAuth error: ${error} - ${errorDescription}`));
+          return;
+        }
+
+        if (returnedState !== state) {
+          res.writeHead(400, { "Content-Type": "text/html" });
+          res.end(`
+            <html>
+              <body style="font-family: sans-serif; padding: 40px;">
+                <h1 style="color: red;">Security Error</h1>
+                <p>State mismatch - possible CSRF attack.</p>
+                <p>You can close this window.</p>
+              </body>
+            </html>
+          `);
+          server.close();
+          reject(new Error("State mismatch"));
+          return;
+        }
+
+        if (!code) {
+          res.writeHead(400, { "Content-Type": "text/html" });
+          res.end(`
+            <html>
+              <body style="font-family: sans-serif; padding: 40px;">
+                <h1 style="color: red;">Error</h1>
+                <p>No authorization code received.</p>
+                <p>You can close this window.</p>
+              </body>
+            </html>
+          `);
+          server.close();
+          reject(new Error("No authorization code"));
+          return;
+        }
+
+        try {
+          // Exchange code for tokens
+          const credentials = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString("base64");
+          const tokenResponse = await axios.post(
+            "https://identity.xero.com/connect/token",
+            new URLSearchParams({
+              grant_type: "authorization_code",
+              code: code,
+              redirect_uri: REDIRECT_URI,
+              code_verifier: codeVerifier,
+            }).toString(),
+            {
+              headers: {
+                Authorization: `Basic ${credentials}`,
+                "Content-Type": "application/x-www-form-urlencoded",
+              },
+            }
+          );
+
+          const tokens: StoredTokenSet = {
+            access_token: tokenResponse.data.access_token,
+            refresh_token: tokenResponse.data.refresh_token,
+            expires_at: Date.now() + tokenResponse.data.expires_in * 1000,
+            token_type: tokenResponse.data.token_type,
+            scope: tokenResponse.data.scope,
+          };
+
+          saveTokens(tokens);
+
+          // Get connected organizations
+          const connectionsResponse = await axios.get("https://api.xero.com/connections", {
+            headers: {
+              Authorization: `Bearer ${tokens.access_token}`,
+              Accept: "application/json",
+            },
+          });
+
+          const connections = connectionsResponse.data;
+
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end(`
+            <html>
+              <body style="font-family: sans-serif; padding: 40px;">
+                <h1 style="color: green;">✓ Authorization Successful!</h1>
+                <p>Tokens have been saved to <code>.xero-tokens.json</code></p>
+                <h3>Connected Organizations:</h3>
+                <ul>
+                  ${connections.map((c: { tenantName: string; tenantId: string }) =>
+                    `<li><strong>${c.tenantName}</strong> (${c.tenantId})</li>`
+                  ).join("")}
+                </ul>
+                <p>You can now close this window and start the MCP server.</p>
+              </body>
+            </html>
+          `);
+
+          console.log("\n✓ Authorization successful!");
+          console.log("\nConnected organizations:");
+          connections.forEach((c: { tenantName: string; tenantId: string }) => {
+            console.log(`  - ${c.tenantName} (${c.tenantId})`);
+          });
+          console.log("\nTokens saved to .xero-tokens.json");
+          console.log("\nYou can now run the MCP server with:");
+          console.log("  XERO_OAUTH_MODE=true node dist/index.js\n");
+
+          server.close();
+          resolve();
+        } catch (err) {
+          const axiosError = err as any;
+          console.error("Token exchange failed:", axiosError.response?.data || axiosError.message);
+          res.writeHead(500, { "Content-Type": "text/html" });
+          res.end(`
+            <html>
+              <body style="font-family: sans-serif; padding: 40px;">
+                <h1 style="color: red;">Token Exchange Failed</h1>
+                <p>${axiosError.response?.data?.error_description || axiosError.message}</p>
+                <p>You can close this window.</p>
+              </body>
+            </html>
+          `);
+          server.close();
+          reject(err);
+        }
+      }
+    });
+
+    server.listen(5000, async () => {
+      console.log("Listening for OAuth callback on http://localhost:5000/callback");
+      console.log("\nOpening browser for authorization...\n");
+
+      try {
+        await open(authUrl.toString());
+      } catch {
+        console.log("Could not open browser automatically.");
+        console.log("Please open this URL manually:\n");
+        console.log(authUrl.toString());
+        console.log();
+      }
+    });
+
+    server.on("error", (err) => {
+      console.error("Server error:", err);
+      reject(err);
+    });
+  });
+}
+
+main().catch((err) => {
+  console.error("Setup failed:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
I had to implement this as a "special connector" workaround because the "special whatever" is not available to Canadian companies.

Add OAuth2 authorization code flow with PKCE as an alternative authentication method alongside existing custom connections and bearer token modes:
- Interactive browser-based OAuth authorization setup
- Automatic token refresh with expiration tracking
- Token persistence via configurable JSON file storage
- Enhanced error handling with diagnostic messages for auth failures
- New OAuthXeroClient class with auto-renewal support