### PR TITLE
fix: cache client_credentials token to avoid redundant auth requests

### DIFF
--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -77,6 +77,10 @@ abstract class MCPXeroClient extends XeroClient {
 class CustomConnectionsXeroClient extends MCPXeroClient {
   private readonly clientId: string;
   private readonly clientSecret: string;
+  private tokenObtainedAt: number = 0;
+  private tokenExpiresInMs: number = 0;
+
+  private static readonly REFRESH_BUFFER_MS = 5 * 60 * 1000; // refresh 5 min before expiry
 
   constructor(config: {
     clientId: string;
@@ -86,6 +90,12 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
     super(config);
     this.clientId = config.clientId;
     this.clientSecret = config.clientSecret;
+  }
+
+  private isTokenValid(): boolean {
+    if (this.tokenExpiresInMs === 0) return false;
+    const elapsed = Date.now() - this.tokenObtainedAt;
+    return elapsed < this.tokenExpiresInMs - CustomConnectionsXeroClient.REFRESH_BUFFER_MS;
   }
 
   public async getClientCredentialsToken(): Promise<TokenSet> {
@@ -134,7 +144,14 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
   }
 
   public async authenticate() {
+    if (this.isTokenValid()) return;
+
     const tokenResponse = await this.getClientCredentialsToken();
+
+    this.tokenObtainedAt = Date.now();
+    if (tokenResponse.expires_in) {
+      this.tokenExpiresInMs = tokenResponse.expires_in * 1000;
+    }
 
     this.setTokenSet({
       access_token: tokenResponse.access_token,


### PR DESCRIPTION
## Problem

Currently, `authenticate()` in `CustomConnectionsXeroClient` fetches a new token from Xero's identity server (`https://identity.xero.com/connect/token`) on **every single tool call**. Since every handler calls `await xeroClient.authenticate()` before making API requests, this results in dozens of unnecessary token requests per session.

This is wasteful and can trigger rate limiting on long-running sessions, causing `Failed to get Xero token` errors — particularly for users who run many tool calls in sequence.

## Fix

Cache the `client_credentials` token and track its expiry using the `expires_in` value from Xero's token response. Only re-authenticate when the token is within 5 minutes of expiring.

**Before:** Every tool call → POST to identity server → new token
**After:** First tool call → POST to identity server → cached; subsequent calls reuse token until ~5 min before expiry

### Changes

- Added `tokenObtainedAt` and `tokenExpiresInMs` tracking fields
- Added `isTokenValid()` method with 5-minute safety buffer
- `authenticate()` returns early if the cached token is still valid
- Zero changes to the public API or handler code

### Impact

- Reduces token endpoint calls from `N` (one per tool call) to `~1 per 25 minutes`
- Eliminates potential rate limiting from Xero's identity server
- No behavior change for `BearerTokenXeroClient`
- Fully backwards compatible