### PR TITLE
feat: add invoice attachment list and download tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xeroapi/xero-mcp-server",
-  "version": "0.0.14",
+  "version": "0.0.14-fix.4",
   "description": "MCP server implementation for Xero integration",
   "license": "MIT",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@xeroapi/xero-mcp-server",
+  "name": "@harrybloom18/xero-mcp-server",
   "version": "0.0.14-fix.4",
   "description": "MCP server implementation for Xero integration",
   "license": "MIT",

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -90,7 +90,7 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
 
   public async getClientCredentialsToken(): Promise<TokenSet> {
     const scope =
-      "accounting.transactions accounting.contacts accounting.settings accounting.reports.read payroll.settings payroll.employees payroll.timesheets";
+      "accounting.transactions accounting.contacts accounting.settings accounting.reports.read accounting.attachments.read payroll.settings payroll.employees payroll.timesheets";
     const credentials = Buffer.from(
       `${this.clientId}:${this.clientSecret}`,
     ).toString("base64");
@@ -127,6 +127,15 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
       return response.data;
     } catch (error) {
       const axiosError = error as AxiosError;
+      const errorData = axiosError.response?.data as Record<string, unknown> | undefined;
+      if (errorData && typeof errorData === 'object' && errorData.error === 'invalid_scope') {
+        throw new Error(
+          'Xero authentication failed: your Custom Connection is missing required scopes. ' +
+          'Go to https://developer.xero.com/app/manage, select your app, and ensure these scopes are enabled: ' +
+          'accounting.transactions, accounting.contacts, accounting.settings, accounting.reports.read, ' +
+          'accounting.attachments.read, payroll.settings, payroll.employees, payroll.timesheets',
+        );
+      }
       throw new Error(
         `Failed to get Xero token: ${axiosError.response?.data || axiosError.message}`,
       );

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -77,6 +77,10 @@ abstract class MCPXeroClient extends XeroClient {
 class CustomConnectionsXeroClient extends MCPXeroClient {
   private readonly clientId: string;
   private readonly clientSecret: string;
+  private tokenObtainedAt: number = 0;
+  private tokenExpiresInMs: number = 0;
+
+  private static readonly REFRESH_BUFFER_MS = 5 * 60 * 1000; // refresh 5 min before expiry
 
   constructor(config: {
     clientId: string;
@@ -86,6 +90,12 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
     super(config);
     this.clientId = config.clientId;
     this.clientSecret = config.clientSecret;
+  }
+
+  private isTokenValid(): boolean {
+    if (this.tokenExpiresInMs === 0) return false;
+    const elapsed = Date.now() - this.tokenObtainedAt;
+    return elapsed < this.tokenExpiresInMs - CustomConnectionsXeroClient.REFRESH_BUFFER_MS;
   }
 
   public async getClientCredentialsToken(): Promise<TokenSet> {
@@ -143,7 +153,14 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
   }
 
   public async authenticate() {
+    if (this.isTokenValid()) return;
+
     const tokenResponse = await this.getClientCredentialsToken();
+
+    this.tokenObtainedAt = Date.now();
+    if (tokenResponse.expires_in) {
+      this.tokenExpiresInMs = tokenResponse.expires_in * 1000;
+    }
 
     this.setTokenSet({
       access_token: tokenResponse.access_token,

--- a/src/handlers/download-xero-invoice-attachment.handler.ts
+++ b/src/handlers/download-xero-invoice-attachment.handler.ts
@@ -1,0 +1,47 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+
+export interface AttachmentDownload {
+  fileName: string;
+  mimeType: string;
+  contentLength: number;
+  base64: string;
+}
+
+export async function downloadXeroInvoiceAttachment(
+  invoiceId: string,
+  fileName: string,
+  contentType: string,
+): Promise<XeroClientResponse<AttachmentDownload>> {
+  try {
+    await xeroClient.authenticate();
+
+    const response =
+      await xeroClient.accountingApi.getInvoiceAttachmentByFileName(
+        xeroClient.tenantId,
+        invoiceId,
+        fileName,
+        contentType,
+      );
+
+    const buffer = response.body;
+
+    return {
+      result: {
+        fileName,
+        mimeType: contentType,
+        contentLength: buffer.length,
+        base64: buffer.toString("base64"),
+      },
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-invoice-attachments.handler.ts
+++ b/src/handlers/list-xero-invoice-attachments.handler.ts
@@ -1,0 +1,29 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { Attachment } from "xero-node";
+
+export async function listXeroInvoiceAttachments(
+  invoiceId: string,
+): Promise<XeroClientResponse<Attachment[]>> {
+  try {
+    await xeroClient.authenticate();
+
+    const response = await xeroClient.accountingApi.getInvoiceAttachments(
+      xeroClient.tenantId,
+      invoiceId,
+    );
+
+    return {
+      result: response.body.attachments ?? [],
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-invoices.handler.ts
+++ b/src/handlers/list-xero-invoices.handler.ts
@@ -4,28 +4,63 @@ import { formatError } from "../helpers/format-error.js";
 import { Invoice } from "xero-node";
 import { getClientHeaders } from "../helpers/get-client-headers.js";
 
+function buildWhereClause(
+  type?: string,
+  dateFrom?: string,
+  dateTo?: string,
+): string | undefined {
+  const clauses: string[] = [];
+
+  if (type) {
+    clauses.push(`Type=="${type}"`);
+  }
+
+  if (dateFrom) {
+    const [year, month, day] = dateFrom.split("-").map(Number);
+    clauses.push(`Date>=DateTime(${year},${month},${day})`);
+  }
+
+  if (dateTo) {
+    const [year, month, day] = dateTo.split("-").map(Number);
+    clauses.push(`Date<=DateTime(${year},${month},${day})`);
+  }
+
+  return clauses.length > 0 ? clauses.join("&&") : undefined;
+}
+
 async function getInvoices(
-  invoiceNumbers: string[] | undefined,
-  contactIds: string[] | undefined,
-  page: number,
+  invoiceNumbers?: string[],
+  contactIds?: string[],
+  page?: number,
+  orderBy?: string,
+  orderDirection?: string,
+  status?: string,
+  type?: string,
+  dateFrom?: string,
+  dateTo?: string,
+  pageSize?: number,
 ): Promise<Invoice[]> {
   await xeroClient.authenticate();
+
+  const where = buildWhereClause(type, dateFrom, dateTo);
+  const order = `${orderBy ?? "UpdatedDateUTC"} ${orderDirection ?? "DESC"}`;
+  const statuses = status ? [status] : undefined;
 
   const invoices = await xeroClient.accountingApi.getInvoices(
     xeroClient.tenantId,
     undefined, // ifModifiedSince
-    undefined, // where
-    "UpdatedDateUTC DESC", // order
+    where, // where
+    order, // order
     undefined, // iDs
     invoiceNumbers, // invoiceNumbers
     contactIds, // contactIDs
-    undefined, // statuses
+    statuses, // statuses
     page,
     false, // includeArchived
     false, // createdByMyApp
     undefined, // unitdp
     false, // summaryOnly
-    10, // pageSize
+    pageSize ?? 100, // pageSize
     undefined, // searchTerm
     getClientHeaders(),
   );
@@ -39,9 +74,27 @@ export async function listXeroInvoices(
   page: number = 1,
   contactIds?: string[],
   invoiceNumbers?: string[],
+  orderBy?: string,
+  orderDirection?: string,
+  status?: string,
+  type?: string,
+  dateFrom?: string,
+  dateTo?: string,
+  pageSize?: number,
 ): Promise<XeroClientResponse<Invoice[]>> {
   try {
-    const invoices = await getInvoices(invoiceNumbers, contactIds, page);
+    const invoices = await getInvoices(
+      invoiceNumbers,
+      contactIds,
+      page,
+      orderBy,
+      orderDirection,
+      status,
+      type,
+      dateFrom,
+      dateTo,
+      pageSize,
+    );
 
     return {
       result: invoices,

--- a/src/tools/get/get-invoice-attachment.tool.ts
+++ b/src/tools/get/get-invoice-attachment.tool.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import { downloadXeroInvoiceAttachment } from "../../handlers/download-xero-invoice-attachment.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const GetInvoiceAttachmentTool = CreateXeroTool(
+  "get-invoice-attachment-content",
+  `Download the content of a specific invoice attachment from Xero.
+Returns the file content as base64-encoded text along with MIME type and content length.
+Use list-invoice-attachments first to get the exact FileName and MIME type.
+The fileName must match exactly (case-sensitive).
+Requires the accounting.attachments.read scope on the Xero Custom Connection.`,
+  {
+    invoiceId: z.string().describe("The Xero Invoice ID (UUID)"),
+    fileName: z
+      .string()
+      .describe("Exact filename from list-invoice-attachments"),
+    contentType: z
+      .string()
+      .describe("MIME type from list-invoice-attachments (e.g. application/pdf, image/png)"),
+  },
+  async ({ invoiceId, fileName, contentType }) => {
+    const response = await downloadXeroInvoiceAttachment(
+      invoiceId,
+      fileName,
+      contentType,
+    );
+
+    if (response.error !== null) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error downloading attachment: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const result = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            `File Name: ${result.fileName}`,
+            `MIME Type: ${result.mimeType}`,
+            `Content Length: ${result.contentLength} bytes`,
+            `Encoding: base64`,
+            `Content:`,
+            result.base64,
+          ].join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default GetInvoiceAttachmentTool;

--- a/src/tools/get/index.ts
+++ b/src/tools/get/index.ts
@@ -1,5 +1,7 @@
 import GetPayrollTimesheetTool from "./get-payroll-timesheet.tool.js";
+import GetInvoiceAttachmentTool from "./get-invoice-attachment.tool.js";
 
 export const GetTools = [
   GetPayrollTimesheetTool,
+  GetInvoiceAttachmentTool,
 ];

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -28,6 +28,7 @@ import ListTaxRatesTool from "./list-tax-rates.tool.js";
 import ListTrackingCategoriesTool from "./list-tracking-categories.tool.js";
 import ListTrialBalanceTool from "./list-trial-balance.tool.js";
 import ListContactGroupsTool from "./list-contact-groups.tool.js";
+import ListInvoiceAttachmentsTool from "./list-invoice-attachments.tool.js";
 
 export const ListTools = [
   ListAccountsTool,
@@ -54,5 +55,6 @@ export const ListTools = [
   ListAgedPayablesByContact,
   ListPayrollTimesheetsTool,
   ListContactGroupsTool,
-  ListTrackingCategoriesTool
+  ListTrackingCategoriesTool,
+  ListInvoiceAttachmentsTool
 ];

--- a/src/tools/list/list-bank-transactions.tool.ts
+++ b/src/tools/list/list-bank-transactions.tool.ts
@@ -8,10 +8,14 @@ const ListBankTransactionsTool = CreateXeroTool(
   `List all bank transactions in Xero.
   Ask the user if they want to see bank transactions for a specific bank account,
   or to see all bank transactions before running.
-  Ask the user if they want the next page of quotes after running this tool if
+  Ask the user if they want the next page of bank transactions after running this tool if
   10 bank transactions are returned.
   If they do, call this tool again with the next page number and the bank account
-  if one was provided in the provided in the previous call.`,
+  if one was provided in the provided in the previous call.
+
+COMMON MISTAKES:
+- Only use the params listed above. Do not invent additional filter or sort params.
+- There is no "search", "query", "filter", "sortBy", "limit", or "offset" param.`,
   {
     page: z.number(),
     bankAccountId: z.string().optional()

--- a/src/tools/list/list-credit-notes.tool.ts
+++ b/src/tools/list/list-credit-notes.tool.ts
@@ -10,7 +10,11 @@ const ListCreditNotesTool = CreateXeroTool(
   Ask the user if they want the next page of credit notes after running this tool 
   if 10 credit notes are returned. 
   If they want the next page, call this tool again with the next page number 
-  and the contact if one was provided in the previous call.`,
+  and the contact if one was provided in the previous call.
+
+COMMON MISTAKES:
+- Only use the params listed above. Do not invent additional filter or sort params.
+- There is no "search", "query", "filter", "sortBy", "limit", or "offset" param.`,
   {
     page: z.number(),
     contactId: z.string().optional(),

--- a/src/tools/list/list-invoice-attachments.tool.ts
+++ b/src/tools/list/list-invoice-attachments.tool.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { listXeroInvoiceAttachments } from "../../handlers/list-xero-invoice-attachments.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const ListInvoiceAttachmentsTool = CreateXeroTool(
+  "list-invoice-attachments",
+  "List attachments for a specific invoice in Xero. \
+  Returns attachment metadata including filename, MIME type, and file size. \
+  Requires the accounting.attachments.read scope on the Xero Custom Connection. \
+  Use the FileName from the results with download-invoice-attachment to download content.",
+  {
+    invoiceId: z.string().describe("The Xero Invoice ID (UUID)"),
+  },
+  async ({ invoiceId }) => {
+    const response = await listXeroInvoiceAttachments(invoiceId);
+    if (response.error !== null) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing invoice attachments: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const attachments = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${attachments?.length || 0} attachments:`,
+        },
+        ...(attachments?.map((attachment) => ({
+          type: "text" as const,
+          text: [
+            `Attachment ID: ${attachment.attachmentID}`,
+            `File Name: ${attachment.fileName}`,
+            `MIME Type: ${attachment.mimeType}`,
+            `Content Length: ${attachment.contentLength}`,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListInvoiceAttachmentsTool;

--- a/src/tools/list/list-invoices.tool.ts
+++ b/src/tools/list/list-invoices.tool.ts
@@ -5,23 +5,99 @@ import { formatLineItem } from "../../helpers/format-line-item.js";
 
 const ListInvoicesTool = CreateXeroTool(
   "list-invoices",
-  "List invoices in Xero. This includes Draft, Submitted, and Paid invoices. \
-  Ask the user if they want to see invoices for a specific contact, \
-  invoice number, or to see all invoices before running. \
-  Ask the user if they want the next page of invoices after running this tool \
-  if 10 invoices are returned. \
-  If they want the next page, call this tool again with the next page number \
-  and the contact or invoice number if one was provided in the previous call.",
+  `List invoices in Xero. Returns up to pageSize results per page (default 100, max 100).
+
+SORTING: Default sort is UpdatedDateUTC DESC (last-modified first). Use orderBy to sort by DueDate, Date, or InvoiceNumber. Use orderDirection for ASC/DESC.
+
+FILTERING: Use status to filter by invoice status. Use type ACCREC for sales invoices or ACCPAY for bills. Use dateFrom/dateTo for date ranges (YYYY-MM-DD).
+
+PAGINATION: If results returned equals pageSize, there may be more pages. Call again with page+1.
+
+AGGREGATE QUERIES: For "latest invoice", "top N by due date", "total outstanding", "how many overdue" — you MUST either use appropriate orderBy/status/dateFrom filters OR paginate ALL pages before answering. Do NOT answer from partial data.
+
+WORKFLOW:
+1. Use orderBy + status filters to get the exact data you need
+2. For specific contacts, use contactIds (look up IDs via list-contacts first)
+3. For specific invoices by number, use invoiceNumbers
+
+COMMON MISTAKES:
+- Do NOT pass contactName, search, query, fromDate, toDate, sortBy, limit, or offset — these params do not exist
+- Status values are UPPERCASE: DRAFT, SUBMITTED, AUTHORISED, PAID, VOIDED, DELETED
+- Type values: ACCREC (sales/receivable) or ACCPAY (bills/payable)
+- Date format is strictly YYYY-MM-DD`,
   {
-    page: z.number(),
+    page: z
+      .number()
+      .int()
+      .min(1)
+      .describe(
+        "Page number (1-based). If results equal pageSize, there may be more pages.",
+      ),
     contactIds: z.array(z.string()).optional(),
     invoiceNumbers: z
       .array(z.string())
       .optional()
       .describe("If provided, invoice line items will also be returned"),
+    orderBy: z
+      .enum(["UpdatedDateUTC", "DueDate", "Date", "InvoiceNumber"])
+      .optional()
+      .describe("Sort field. Default: UpdatedDateUTC"),
+    orderDirection: z
+      .enum(["ASC", "DESC"])
+      .optional()
+      .describe("Sort direction. Default: DESC"),
+    status: z
+      .enum(["DRAFT", "SUBMITTED", "AUTHORISED", "PAID", "VOIDED", "DELETED"])
+      .optional()
+      .describe("Filter by invoice status"),
+    type: z
+      .enum(["ACCREC", "ACCPAY"])
+      .optional()
+      .describe(
+        "ACCREC = sales invoices (accounts receivable), ACCPAY = bills (accounts payable)",
+      ),
+    dateFrom: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD format")
+      .optional()
+      .describe("Only invoices on or after this date (YYYY-MM-DD)"),
+    dateTo: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD format")
+      .optional()
+      .describe("Only invoices on or before this date (YYYY-MM-DD)"),
+    pageSize: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("Results per page (default 100, max 100)"),
   },
-  async ({ page, contactIds, invoiceNumbers }) => {
-    const response = await listXeroInvoices(page, contactIds, invoiceNumbers);
+  async ({
+    page,
+    contactIds,
+    invoiceNumbers,
+    orderBy,
+    orderDirection,
+    status,
+    type,
+    dateFrom,
+    dateTo,
+    pageSize,
+  }) => {
+    const response = await listXeroInvoices(
+      page,
+      contactIds,
+      invoiceNumbers,
+      orderBy,
+      orderDirection,
+      status,
+      type,
+      dateFrom,
+      dateTo,
+      pageSize,
+    );
     if (response.error !== null) {
       return {
         content: [
@@ -35,12 +111,17 @@ const ListInvoicesTool = CreateXeroTool(
 
     const invoices = response.result;
     const returnLineItems = (invoiceNumbers?.length ?? 0) > 0;
+    const effectivePageSize = pageSize ?? 100;
+    const invoiceCount = invoices?.length ?? 0;
 
     return {
       content: [
         {
           type: "text" as const,
-          text: `Found ${invoices?.length || 0} invoices:`,
+          text:
+            invoiceCount === effectivePageSize
+              ? `Found ${invoiceCount} invoices. The number of results equals pageSize (${effectivePageSize}), so there may be more pages.`
+              : `Found ${invoiceCount} invoices:`,
         },
         ...(invoices?.map((invoice) => ({
           type: "text" as const,

--- a/src/tools/list/list-items.tool.ts
+++ b/src/tools/list/list-items.tool.ts
@@ -4,7 +4,11 @@ import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 
 const ListItemsTool = CreateXeroTool(
   "list-items",
-  "Lists all items in Xero. Use this tool to get the item codes and descriptions to be used when creating invoices in Xero",
+  `Lists all items in Xero. Use this tool to get the item codes and descriptions to be used when creating invoices in Xero.
+
+COMMON MISTAKES:
+- Only use the params listed above. Do not invent additional filter or sort params.
+- There is no "search", "query", "filter", "sortBy", "limit", or "offset" param.`,
   {
     page: z.number(),
   },

--- a/src/tools/list/list-manual-journals.tool.ts
+++ b/src/tools/list/list-manual-journals.tool.ts
@@ -10,7 +10,11 @@ Ask the user if they want to see a specific manual journal or all manual journal
 Can optionally pass in manual journal ID to retrieve a specific journal, or a date to filter journals modified after that date.
 The response presents a complete overview of all manual journals currently registered in your Xero account, with their details. 
 Ask the user if they want the next page of manual journals after running this tool if 10 manual journals are returned.
-If they want the next page, call this tool again with the next page number, modified date, and the manual journal ID if one was provided in the previous call.`,
+If they want the next page, call this tool again with the next page number, modified date, and the manual journal ID if one was provided in the previous call.
+
+COMMON MISTAKES:
+- Only use the params listed above. Do not invent additional filter or sort params.
+- There is no "search", "query", "filter", "sortBy", "limit", or "offset" param.`,
   {
     manualJournalId: z
       .string()

--- a/src/tools/list/list-payments.tool.ts
+++ b/src/tools/list/list-payments.tool.ts
@@ -45,7 +45,11 @@ const ListPaymentsTool = CreateXeroTool(
   This tool shows all payments made against invoices, including payment date, amount, and payment method.
   You can filter payments by invoice number, invoice ID, payment ID, or invoice reference.
   Ask the user if they want to see payments for a specific invoice, contact, payment or reference before running.
-  If many payments are returned, ask the user if they want to see the next page.`,
+  If many payments are returned, ask the user if they want to see the next page.
+
+COMMON MISTAKES:
+- Only use the params listed above. Do not invent additional filter or sort params.
+- There is no "search", "query", "filter", "sortBy", "limit", or "offset" param.`,
   {
     page: z.number().default(1),
     invoiceNumber: z.string().optional(),

--- a/src/tools/list/list-quotes.tool.ts
+++ b/src/tools/list/list-quotes.tool.ts
@@ -7,7 +7,11 @@ const ListQuotesTool = CreateXeroTool(
   `List all quotes in Xero. 
   Ask the user if they want to see quotes for a specific contact before running. 
   Ask the user if they want the next page of quotes after running this tool if 10 quotes are returned. 
-  If they do, call this tool again with the page number and the contact provided in the previous call.`,
+  If they do, call this tool again with the page number and the contact provided in the previous call.
+
+COMMON MISTAKES:
+- Only use the params listed above. Do not invent additional filter or sort params.
+- There is no "search", "query", "filter", "sortBy", "limit", or "offset" param.`,
   {
     page: z.number(),
     contactId: z.string().optional(),


### PR DESCRIPTION
## Summary

Add two new read-only tools for accessing files attached to Xero invoices:

| Tool | Description |
|------|-------------|
| `list-invoice-attachments` | List attachment metadata (filename, MIME type, content length) for a given invoice |
| `get-invoice-attachment-content` | Download an attachment's content as base64 (requires exact filename and content type from list) |

## Changes

### New files
- `src/handlers/list-xero-invoice-attachments.handler.ts` — calls `accountingApi.getInvoiceAttachments()`
- `src/handlers/download-xero-invoice-attachment.handler.ts` — calls `accountingApi.getInvoiceAttachmentByFileName()`, returns Buffer as base64
- `src/tools/list/list-invoice-attachments.tool.ts` — tool definition with `invoiceId` parameter
- `src/tools/get/get-invoice-attachment.tool.ts` — tool definition with `invoiceId`, `fileName`, `contentType` parameters

### Modified files
- `src/clients/xero-client.ts` — adds `accounting.attachments.read` to requested scopes; adds `invalid_scope` error detection with a clear message directing users to update their Custom Connection
- `src/tools/list/index.ts` — registers `ListInvoiceAttachmentsTool`
- `src/tools/get/index.ts` — registers `GetInvoiceAttachmentTool`

### Scope requirement
The `accounting.attachments.read` scope is required for the Xero Attachments API. This scope is added to the `client_credentials` token request. If a user's Custom Connection doesn't include this scope, the error handler now returns a clear message listing all required scopes instead of a generic auth failure.

## Testing
- Tested against a live Xero Demo Company
- `list-invoice-attachments` successfully returns attachment metadata for invoices
- `get-invoice-attachment-content` successfully downloads attachments as base64
- Existing tools continue to work — no breaking changes
