### PR TITLE
update with scope info

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ In this case, use the following configuration:
 
 NOTE: The `XERO_CLIENT_BEARER_TOKEN` will take precedence over the `XERO_CLIENT_ID` if defined.
 
+##### Required Scopes for Bearer Token
+
+When obtaining a bearer token, you must request the appropriate scopes. The scopes you request should match what your Xero app has been configured with.
+
+See [Xero OAuth 2.0 Scopes](https://developer.xero.com/documentation/guides/oauth2/scopes/) for the complete list of available scopes.
+
 ### Available MCP Commands
 
 - `list-accounts`: Retrieve a list of accounts

--- a/README.md
+++ b/README.md
@@ -108,13 +108,11 @@ accounting.banktransactions
 accounting.banktransactions.read
 accounting.manualjournals
 accounting.manualjournals.read
-
 accounting.reports.read (Deprecated)
 accounting.reports.aged.read
 accounting.reports.balancesheet.read
 accounting.reports.profitandloss.read
 accounting.reports.trialbalance.read
-
 accounting.contacts 
 accounting.settings 
 payroll.settings 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,35 @@ NOTE: The `XERO_CLIENT_BEARER_TOKEN` will take precedence over the `XERO_CLIENT_
 
 ##### Required Scopes for Bearer Token
 
-When obtaining a bearer token, you must request the appropriate scopes. The scopes you request should match what your Xero app has been configured with.
+When obtaining a bearer token, you must request the appropriate scopes. The scopes you request should be:
 
-See [Xero OAuth 2.0 Scopes](https://developer.xero.com/documentation/guides/oauth2/scopes/) for the complete list of available scopes.
+> **Note:** Some scopes are being deprecated in favour of more granular scopes. See the [Xero OAuth 2.0 Scopes documentation](https://developer.xero.com/documentation/guides/oauth2/scopes/) for details on deprecation timelines.
+
+```
+accounting.transactions (Deprecated)
+accounting.transactions.read (Deprecated)
+accounting.invoices
+accounting.invoices.read
+accounting.payments
+accounting.payments.read
+accounting.banktransactions
+accounting.banktransactions.read
+accounting.manualjournals
+accounting.manualjournals.read
+
+accounting.reports.read (Deprecated)
+accounting.reports.aged.read
+accounting.reports.balancesheet.read
+accounting.reports.profitandloss.read
+accounting.reports.trialbalance.read
+
+accounting.contacts 
+accounting.settings 
+payroll.settings 
+payroll.employees 
+payroll.timesheets
+```
+
 
 ### Available MCP Commands
 
@@ -104,13 +130,13 @@ See [Xero OAuth 2.0 Scopes](https://developer.xero.com/documentation/guides/oaut
 - `list-credit-notes`: Retrieve a list of credit notes
 - `list-invoices`: Retrieve a list of invoices
 - `list-items`: Retrieve a list of items
+- `list-manual-journals`: Retrieve a list of manual journals
 - `list-organisation-details`: Retrieve details about an organisation
 - `list-profit-and-loss`: Retrieve a profit and loss report
 - `list-quotes`: Retrieve a list of quotes
 - `list-tax-rates`: Retrieve a list of tax rates
 - `list-payments`: Retrieve a list of payments
 - `list-trial-balance`: Retrieve a trial balance report
-- `list-profit-and-loss`: Retrieve a profit and loss report
 - `list-bank-transactions`: Retrieve a list of bank account transactions
 - `list-payroll-employees`: Retrieve a list of Payroll Employees
 - `list-report-balance-sheet`: Retrieve a balance sheet report
@@ -118,21 +144,32 @@ See [Xero OAuth 2.0 Scopes](https://developer.xero.com/documentation/guides/oaut
 - `list-payroll-employee-leave-balances`: Retrieve a Payroll Employee's leave balances
 - `list-payroll-employee-leave-types`: Retrieve a list of Payroll leave types
 - `list-payroll-leave-periods`: Retrieve a list of a Payroll Employee's leave periods
-- `list-payroll-leave-types`: Retrieve a list of all avaliable leave types in Xero Payroll
+- `list-payroll-leave-types`: Retrieve a list of all available leave types in Xero Payroll
+- `list-timesheets`: Retrieve a list of Payroll Timesheets
 - `list-aged-receivables-by-contact`: Retrieves aged receivables for a contact
 - `list-aged-payables-by-contact`: Retrieves aged payables for a contact
 - `list-contact-groups`: Retrieve a list of contact groups
+- `list-tracking-categories`: Retrieve a list of tracking categories
+- `create-bank-transaction`: Create a new bank transaction
 - `create-contact`: Create a new contact
 - `create-credit-note`: Create a new credit note
 - `create-invoice`: Create a new invoice
+- `create-item`: Create a new item
+- `create-manual-journal`: Create a new manual journal
 - `create-payment`: Create a new payment
 - `create-quote`: Create a new quote
-- `create-credit-note`: Create a new credit note
 - `create-payroll-timesheet`: Create a new Payroll Timesheet
+- `create-tracking-category`: Create a new tracking category
+- `create-tracking-option`: Create a new tracking option
+- `update-bank-transaction`: Update an existing bank transaction
 - `update-contact`: Update an existing contact
 - `update-invoice`: Update an existing draft invoice
+- `update-item`: Update an existing item
+- `update-manual-journal`: Update an existing manual journal
 - `update-quote`: Update an existing draft quote
 - `update-credit-note`: Update an existing draft credit note
+- `update-tracking-category`: Update an existing tracking category
+- `update-tracking-options`: Update tracking options
 - `update-payroll-timesheet-line`: Update a line on an existing Payroll Timesheet
 - `approve-payroll-timesheet`: Approve a Payroll Timesheet
 - `revert-payroll-timesheet`: Revert an approved Payroll Timesheet


### PR DESCRIPTION
**Changes**
1. Added "Required Scopes for Bearer Token" section documenting all scopes needed for Authorization Code/PKCE flows
2. Added deprecation notice with link to [Xero OAuth 2.0 Scopes documentation](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
3. Added missing MCP commands to documentation
4. Removed duplicate entries

**Granular scopes not included**
The following granular scopes are not included in the required scopes list as there are no corresponding MCP tools to support them:
```
accounting.reports.banksummary.read
accounting.reports.budgetsummary.read
accounting.reports.executivesummary.read
accounting.reports.taxreports.read
```