### PR TITLE
Make custom connection scopes configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ It is also the recommended approach if you are integrating this into 3rd party M
 
 Set up a Custom Connection following these instructions: https://developer.xero.com/documentation/guides/oauth2/custom-connections/
 
-=======
 ##### Required Scopes
 
 Custom connections require different scopes depending on when they were created. **All scopes in the relevant list must be added to your custom connection:**

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Custom connections require different scopes depending on when they were created.
 | After Apr 27, 2026 | [SCOPES_V2](src/clients/xero-client.ts#L93-L112) (granular permissions) |
 
 > **Note:** The MCP server automatically tries V1 scopes first and falls back to V2 if needed.
+> 
 > You can override these by setting the `XERO_SCOPES` environment variable to a space-separated list of scopes.
 
 ##### Integrating the MCP server with Claude Desktop
@@ -73,7 +74,7 @@ To add the MCP server to Claude go to Settings > Developer > Edit config and add
       "env": {
         "XERO_CLIENT_ID": "your_client_id_here",
         "XERO_CLIENT_SECRET": "your_client_secret_here",
-        "XERO_SCOPES": "accounting.transactions accounting.contacts accounting.settings"
+        "XERO_SCOPES": "accounting.invoices accounting.contacts accounting.settings"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,19 @@ It is also the recommended approach if you are integrating this into 3rd party M
 
 Set up a Custom Connection following these instructions: https://developer.xero.com/documentation/guides/oauth2/custom-connections/
 
-Currently the following scopes are required for all sessions: [scopes](src/clients/xero-client.ts#L91-L92)
+The following [scopes](src/clients/xero-client.ts#L91-L92) are requested by default for all custom connection sessions:
+
+```
+accounting.transactions
+accounting.contacts
+accounting.settings
+accounting.reports.read
+payroll.settings
+payroll.employees
+payroll.timesheets
+```
+
+You can override these by setting the `XERO_SCOPES` environment variable to a space-separated list of scopes.
 
 ##### Integrating the MCP server with Claude Desktop
 
@@ -61,12 +73,15 @@ To add the MCP server to Claude go to Settings > Developer > Edit config and add
       "args": ["-y", "@xeroapi/xero-mcp-server@latest"],
       "env": {
         "XERO_CLIENT_ID": "your_client_id_here",
-        "XERO_CLIENT_SECRET": "your_client_secret_here"
+        "XERO_CLIENT_SECRET": "your_client_secret_here",
+        "XERO_SCOPES": "accounting.transactions accounting.contacts accounting.settings"
       }
     }
   }
 }
 ```
+
+The `XERO_SCOPES` variable is optional. If omitted, the default scopes listed above will be used.
 
 NOTE: If you are using [Node Version Manager](https://github.com/nvm-sh/nvm) `"command": "npx"` section change it to be the full path to the executable, ie: `your_home_directory/.nvm/versions/node/v22.14.0/bin/npx` on Mac / Linux or `"your_home_directory\\.nvm\\versions\\node\\v22.14.0\\bin\\npx"` on Windows
 

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -125,7 +125,6 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
   }
 
   public async getClientCredentialsToken(): Promise<TokenSet> {
-
     // If XERO_SCOPES is set, use that
     if (process.env.XERO_SCOPES) {                                                                                                                                                     
       try {

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -89,8 +89,9 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
   }
 
   public async getClientCredentialsToken(): Promise<TokenSet> {
-    const scope =
+    const defaultScopes =
       "accounting.transactions accounting.contacts accounting.settings accounting.reports.read payroll.settings payroll.employees payroll.timesheets";
+    const scope = process.env.XERO_SCOPES || defaultScopes;
     const credentials = Buffer.from(
       `${this.clientId}:${this.clientSecret}`,
     ).toString("base64");


### PR DESCRIPTION
Problem:

Currently, scopes for custom connection integrations using this mcp server have to have all of the hardcoded scopes, or "invalid token" is returned.

I want to lock down the functionality to read-only at the scope level, rather than relying on higher level checks.

Proposed solution:

The current scopes are set as the default but can be overridden with environment variable "XERO_SCOPES".