### PR TITLE
feat: scope-aware tool registration (extends #136)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,12 @@
 # Xero API Configuration for Custom Connections
 XERO_CLIENT_ID=your_client_id_here
-XERO_CLIENT_SECRET=your_client_secret_here 
+XERO_CLIENT_SECRET=your_client_secret_here
+
+# Optional: space-separated OAuth scopes for custom connections (defaults match README).
+# XERO_SCOPES=accounting.transactions accounting.contacts accounting.settings accounting.reports.read payroll.settings payroll.employees payroll.timesheets
+
+# Optional: use a pre-obtained bearer token instead of client id/secret (takes precedence when set).
+# XERO_CLIENT_BEARER_TOKEN=
+
+# Optional: log to stderr how many MCP tools were registered vs omitted by XERO_SCOPES (custom connections only).
+# XERO_MCP_LOG_SCOPE_FILTERING=1

--- a/README.md
+++ b/README.md
@@ -47,7 +47,19 @@ It is also the recommended approach if you are integrating this into 3rd party M
 
 Set up a Custom Connection following these instructions: https://developer.xero.com/documentation/guides/oauth2/custom-connections/
 
-Currently the following scopes are required for all sessions: [scopes](src/clients/xero-client.ts#L91-L92)
+The following [scopes](src/clients/xero-client.ts#L91-L92) are requested by default for all custom connection sessions:
+
+```
+accounting.transactions
+accounting.contacts
+accounting.settings
+accounting.reports.read
+payroll.settings
+payroll.employees
+payroll.timesheets
+```
+
+You can override these by setting the `XERO_SCOPES` environment variable to a space-separated list of scopes.
 
 ##### Integrating the MCP server with Claude Desktop
 
@@ -61,12 +73,15 @@ To add the MCP server to Claude go to Settings > Developer > Edit config and add
       "args": ["-y", "@xeroapi/xero-mcp-server@latest"],
       "env": {
         "XERO_CLIENT_ID": "your_client_id_here",
-        "XERO_CLIENT_SECRET": "your_client_secret_here"
+        "XERO_CLIENT_SECRET": "your_client_secret_here",
+        "XERO_SCOPES": "accounting.transactions accounting.contacts accounting.settings"
       }
     }
   }
 }
 ```
+
+The `XERO_SCOPES` variable is optional. If omitted, the default scopes listed above will be used.
 
 NOTE: If you are using [Node Version Manager](https://github.com/nvm-sh/nvm) `"command": "npx"` section change it to be the full path to the executable, ie: `your_home_directory/.nvm/versions/node/v22.14.0/bin/npx` on Mac / Linux or `"your_home_directory\\.nvm\\versions\\node\\v22.14.0\\bin\\npx"` on Windows
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It is also the recommended approach if you are integrating this into 3rd party M
 
 Set up a Custom Connection following these instructions: https://developer.xero.com/documentation/guides/oauth2/custom-connections/
 
-The following [scopes](src/clients/xero-client.ts#L91-L92) are requested by default for all custom connection sessions:
+The following [default scopes](src/helpers/scopes.ts) are requested for all custom connection sessions when `XERO_SCOPES` is not set:
 
 ```
 accounting.transactions
@@ -60,6 +60,25 @@ payroll.timesheets
 ```
 
 You can override these by setting the `XERO_SCOPES` environment variable to a space-separated list of scopes.
+
+When using **custom connections**, tools are **registered only if** your configured scopes satisfy each tool’s requirements (see table below). That avoids offering payroll (or other) tools when the access token would not have permission. Typos or unknown scope names log a warning but are still sent to the token endpoint.
+
+Tool registration compares against **custom-connection style** names (e.g. `accounting.transactions`). If you set `XERO_SCOPES` to **granular** names from the bearer-token list below (e.g. `accounting.invoices` only), tools expecting `accounting.transactions` will not register even though your token may be valid—either include the matching broad scope or use bearer token mode (which registers all tools).
+
+Set `XERO_MCP_LOG_SCOPE_FILTERING=1` to print how many tools were registered vs omitted (to **stderr**; safe for MCP stdio transports).
+
+When using **bearer token** auth, `XERO_SCOPES` is not applied to token issuance (your token was created elsewhere). **All tools are registered** in that mode—ensure the token’s scopes match the APIs you use.
+
+##### Scope groups and MCP tools
+
+| Required scopes (all must be present) | MCP tools |
+| --- | --- |
+| `accounting.transactions` | Invoices, credit notes, quotes, payments, bank transactions, manual journals (list / create / update) |
+| `accounting.contacts` | Contacts, contact groups (list / create / update) |
+| `accounting.settings` | Accounts, items, tax rates, tracking categories and options, organisation details |
+| `accounting.reports.read` | Profit and loss, balance sheet, trial balance, aged receivables / payables by contact |
+| `payroll.settings` and `payroll.employees` | Payroll employees, employee leave, leave types, leave periods, leave balances |
+| `payroll.settings` and `payroll.timesheets` | Payroll timesheets (list, get, create, delete, approve, revert, add/update lines) |
 
 ##### Integrating the MCP server with Claude Desktop
 
@@ -74,7 +93,7 @@ To add the MCP server to Claude go to Settings > Developer > Edit config and add
       "env": {
         "XERO_CLIENT_ID": "your_client_id_here",
         "XERO_CLIENT_SECRET": "your_client_secret_here",
-        "XERO_SCOPES": "accounting.transactions accounting.contacts accounting.settings"
+        "XERO_SCOPES": "accounting.transactions accounting.contacts accounting.settings accounting.reports.read"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,7 +399,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -630,7 +629,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1087,7 +1085,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1311,7 +1308,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1743,7 +1739,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2331,7 +2326,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2828,7 +2822,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2985,7 +2978,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -8,6 +8,7 @@ import {
 } from "xero-node";
 
 import { ensureError } from "../helpers/ensure-error.js";
+import { getConfiguredScopeString } from "../helpers/scopes.js";
 
 dotenv.config();
 
@@ -89,9 +90,7 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
   }
 
   public async getClientCredentialsToken(): Promise<TokenSet> {
-    const defaultScopes =
-      "accounting.transactions accounting.contacts accounting.settings accounting.reports.read payroll.settings payroll.employees payroll.timesheets";
-    const scope = process.env.XERO_SCOPES || defaultScopes;
+    const scope = getConfiguredScopeString();
     const credentials = Buffer.from(
       `${this.clientId}:${this.clientSecret}`,
     ).toString("base64");

--- a/src/clients/xero-client.ts
+++ b/src/clients/xero-client.ts
@@ -89,8 +89,9 @@ class CustomConnectionsXeroClient extends MCPXeroClient {
   }
 
   public async getClientCredentialsToken(): Promise<TokenSet> {
-    const scope =
+    const defaultScopes =
       "accounting.transactions accounting.contacts accounting.settings accounting.reports.read payroll.settings payroll.employees payroll.timesheets";
+    const scope = process.env.XERO_SCOPES || defaultScopes;
     const credentials = Buffer.from(
       `${this.clientId}:${this.clientSecret}`,
     ).toString("base64");

--- a/src/helpers/create-xero-tool.ts
+++ b/src/helpers/create-xero-tool.ts
@@ -8,10 +8,12 @@ export const CreateXeroTool =
     description: string,
     schema: Args,
     handler: ToolCallback<Args>,
+    requiredScopes: string[] = [],
   ): (() => ToolDefinition<ZodRawShapeCompat>) =>
   () => ({
     name: name,
     description: description,
     schema: schema,
     handler: handler,
+    requiredScopes,
   });

--- a/src/helpers/scopes.ts
+++ b/src/helpers/scopes.ts
@@ -1,0 +1,122 @@
+/**
+ * OAuth scopes for custom connections and tool gating.
+ * @see https://developer.xero.com/documentation/guides/oauth2/scopes/
+ */
+
+/** Space-separated scopes requested for custom connections when `XERO_SCOPES` is unset. */
+export const DEFAULT_SCOPE_STRING =
+  "accounting.transactions accounting.contacts accounting.settings accounting.reports.read payroll.settings payroll.employees payroll.timesheets";
+
+/**
+ * Known Xero OAuth2 scope strings (custom-connection style + common granular bearer scopes).
+ * Unknown scopes from `XERO_SCOPES` are still passed through to the token request after a warning.
+ */
+export const VALID_SCOPES: ReadonlySet<string> = new Set([
+  // Accounting — custom connection / legacy
+  "accounting.transactions",
+  "accounting.transactions.read",
+  "accounting.contacts",
+  "accounting.settings",
+  "accounting.reports.read",
+  // Granular accounting (bearer / newer apps)
+  "accounting.invoices",
+  "accounting.invoices.read",
+  "accounting.payments",
+  "accounting.payments.read",
+  "accounting.banktransactions",
+  "accounting.banktransactions.read",
+  "accounting.manualjournals",
+  "accounting.manualjournals.read",
+  "accounting.reports.aged.read",
+  "accounting.reports.balancesheet.read",
+  "accounting.reports.profitandloss.read",
+  "accounting.reports.trialbalance.read",
+  // Payroll
+  "payroll.settings",
+  "payroll.employees",
+  "payroll.timesheets",
+  "payroll.payruns",
+  "payroll.payslip",
+]);
+
+const ENV_KEY = "XERO_SCOPES";
+
+function splitScopeString(raw: string): string[] {
+  return raw
+    .trim()
+    .split(/\s+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** True when using client id/secret (custom connections); false when bearer token overrides. */
+export function isCustomConnectionsAuthMode(): boolean {
+  return !process.env.XERO_CLIENT_BEARER_TOKEN?.trim();
+}
+
+let cachedScopes: Set<string> | undefined;
+let cachedScopeString: string | undefined;
+
+function parseAndValidateScopeString(scopeString: string): Set<string> {
+  const parts = splitScopeString(scopeString);
+  if (parts.length === 0) {
+    throw new Error(
+      `No OAuth scopes after parsing (whitespace-only or invalid ${ENV_KEY}?). Provide a space-separated list or unset ${ENV_KEY} to use defaults.`,
+    );
+  }
+  const result = new Set<string>();
+  for (const scope of parts) {
+    if (!VALID_SCOPES.has(scope)) {
+      console.warn(
+        `[xero-mcp-server] Unknown OAuth scope "${scope}" (not in built-in allowlist). It will still be sent to Xero. Check for typos.`,
+      );
+    }
+    result.add(scope);
+  }
+  return result;
+}
+
+/**
+ * Parsed scopes for the current process. Used for custom-connection token requests and tool registration.
+ * Cached after first call.
+ */
+export function getConfiguredScopes(): Set<string> {
+  if (cachedScopes) {
+    return cachedScopes;
+  }
+  const raw = process.env[ENV_KEY]?.trim();
+  const scopeString = raw && raw.length > 0 ? raw : DEFAULT_SCOPE_STRING;
+  cachedScopes = parseAndValidateScopeString(scopeString);
+  cachedScopeString = [...cachedScopes].join(" ");
+  return cachedScopes;
+}
+
+/** Space-separated scopes for the identity server token request (custom connections). */
+export function getConfiguredScopeString(): string {
+  if (cachedScopeString) {
+    return cachedScopeString;
+  }
+  getConfiguredScopes();
+  return cachedScopeString!;
+}
+
+/** Whether a tool's required scopes are all present in the configured set. */
+export function scopesSatisfyTool(
+  configured: Set<string>,
+  requiredScopes: string[] | undefined,
+): boolean {
+  if (!requiredScopes?.length) {
+    return true;
+  }
+  return requiredScopes.every((s) => configured.has(s));
+}
+
+/** Declarative scope groups for MCP tools (custom-connection scope names). */
+export const ToolScopes = {
+  accountingTransactions: ["accounting.transactions"],
+  accountingContacts: ["accounting.contacts"],
+  accountingSettings: ["accounting.settings"],
+  accountingReportsRead: ["accounting.reports.read"],
+  payrollEmployees: ["payroll.settings", "payroll.employees"],
+  payrollTimesheets: ["payroll.settings", "payroll.timesheets"],
+} as const satisfies Record<string, string[]>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import "dotenv/config";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { XeroMcpServer } from "./server/xero-mcp-server.js";
 import { ToolFactory } from "./tools/tool-factory.js";

--- a/src/tools/create/create-bank-transaction.tool.ts
+++ b/src/tools/create/create-bank-transaction.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { createXeroBankTransaction } from "../../handlers/create-xero-bank-transaction.handler.js";
 import { bankTransactionDeepLink } from "../../consts/deeplinks.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const lineItemSchema = z.object({
   description: z.string(),
@@ -63,7 +64,8 @@ const CreateBankTransactionTool = CreateXeroTool(
         },
       ],
     };
-  }
+  },
+  ToolScopes.accountingTransactions
 );
 
 export default CreateBankTransactionTool;

--- a/src/tools/create/create-contact.tool.ts
+++ b/src/tools/create/create-contact.tool.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { ensureError } from "../../helpers/ensure-error.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const CreateContactTool = CreateXeroTool(
   "create-contact",
@@ -61,6 +62,7 @@ const CreateContactTool = CreateXeroTool(
       };
     }
   },
+  ToolScopes.accountingContacts
 );
 
 export default CreateContactTool;

--- a/src/tools/create/create-credit-note.tool.ts
+++ b/src/tools/create/create-credit-note.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createXeroCreditNote } from "../../handlers/create-xero-credit-note.handler.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const lineItemSchema = z.object({
   description: z.string(),
@@ -59,6 +60,7 @@ const CreateCreditNoteTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default CreateCreditNoteTool;

--- a/src/tools/create/create-invoice.tool.ts
+++ b/src/tools/create/create-invoice.tool.ts
@@ -3,6 +3,7 @@ import { createXeroInvoice } from "../../handlers/create-xero-invoice.handler.js
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { Invoice } from "xero-node";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const trackingSchema = z.object({
   name: z.string().describe("The name of the tracking category. Can be obtained from the list-tracking-categories tool"),
@@ -85,6 +86,7 @@ const CreateInvoiceTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default CreateInvoiceTool;

--- a/src/tools/create/create-item.tool.ts
+++ b/src/tools/create/create-item.tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { createXeroItem } from "../../handlers/create-xero-item.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const purchaseDetailsSchema = z.object({
   unitPrice: z.number(),
@@ -77,6 +78,7 @@ const CreateItemTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingSettings
 );
 
 export default CreateItemTool; 

--- a/src/tools/create/create-manual-journal.tool.ts
+++ b/src/tools/create/create-manual-journal.tool.ts
@@ -4,6 +4,7 @@ import { createXeroManualJournal } from "../../handlers/create-xero-manual-journ
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { ensureError } from "../../helpers/ensure-error.js";
 import { LineAmountTypes, ManualJournal } from "xero-node";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const CreateManualJournalTool = CreateXeroTool(
   "create-manual-journal",
@@ -145,6 +146,7 @@ const CreateManualJournalTool = CreateXeroTool(
       };
     }
   },
+  ToolScopes.accountingTransactions
 );
 
 export default CreateManualJournalTool;

--- a/src/tools/create/create-payment.tool.ts
+++ b/src/tools/create/create-payment.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createXeroPayment } from "../../handlers/create-xero-payment.handler.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const CreatePaymentTool = CreateXeroTool(
   "create-payment",
@@ -76,6 +77,7 @@ const CreatePaymentTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default CreatePaymentTool;

--- a/src/tools/create/create-payroll-timesheet.tool.ts
+++ b/src/tools/create/create-payroll-timesheet.tool.ts
@@ -5,6 +5,7 @@ import {
   createXeroPayrollTimesheet,
 } from "../../handlers/create-xero-payroll-timesheet.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const CreatePayrollTimesheetTool = CreateXeroTool(
   "create-timesheet",
@@ -51,6 +52,7 @@ This allows you to specify details such as the employee ID, payroll calendar ID,
       ],
     };
   },
+  ToolScopes.payrollTimesheets
 );
 
 export default CreatePayrollTimesheetTool;

--- a/src/tools/create/create-quote.tool.ts
+++ b/src/tools/create/create-quote.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createXeroQuote } from "../../handlers/create-xero-quote.handler.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const lineItemSchema = z.object({
   description: z.string(),
@@ -79,6 +80,7 @@ const CreateQuoteTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default CreateQuoteTool;

--- a/src/tools/create/create-tracking-category.tool.ts
+++ b/src/tools/create/create-tracking-category.tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { createXeroTrackingCategory } from "../../handlers/create-xero-tracking-category.handler.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const CreateTrackingCategoryTool = CreateXeroTool(
   "create-tracking-category",
@@ -32,7 +33,8 @@ const CreateTrackingCategoryTool = CreateXeroTool(
         },
       ]
     };
-  }
+  },
+  ToolScopes.accountingSettings
 );
 
 export default CreateTrackingCategoryTool;

--- a/src/tools/create/create-tracking-options.tool.ts
+++ b/src/tools/create/create-tracking-options.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { formatTrackingOption } from "../../helpers/format-tracking-option.js";
 import { createXeroTrackingOptions } from "../../handlers/create-xero-tracking-option.handler.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const CreateTrackingOptionsTool = CreateXeroTool(
   "create-tracking-options",
@@ -34,7 +35,8 @@ const CreateTrackingOptionsTool = CreateXeroTool(
         },
       ]
     };
-  }
+  },
+  ToolScopes.accountingSettings
 );
 
 export default CreateTrackingOptionsTool;

--- a/src/tools/delete/delete-payroll-timesheet.tool.ts
+++ b/src/tools/delete/delete-payroll-timesheet.tool.ts
@@ -4,6 +4,7 @@ import {
   deleteXeroPayrollTimesheet,
 } from "../../handlers/delete-xero-payroll-timesheet.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const DeletePayrollTimesheetTool = CreateXeroTool(
   "delete-timesheet",
@@ -35,6 +36,7 @@ const DeletePayrollTimesheetTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.payrollTimesheets
 );
 
 export default DeletePayrollTimesheetTool;

--- a/src/tools/get/get-payroll-timesheet.tool.ts
+++ b/src/tools/get/get-payroll-timesheet.tool.ts
@@ -4,6 +4,7 @@ import {
   getXeroPayrollTimesheet,
 } from "../../handlers/get-xero-payroll-timesheet.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const GetPayrollTimesheetTool = CreateXeroTool(
   "get-timesheet",
@@ -58,6 +59,7 @@ This provides details such as the timesheet ID, employee ID, start and end dates
       ],
     };
   },
+  ToolScopes.payrollTimesheets
 );
 
 export default GetPayrollTimesheetTool;

--- a/src/tools/list/list-accounts.tool.ts
+++ b/src/tools/list/list-accounts.tool.ts
@@ -1,5 +1,6 @@
 import { listXeroAccounts } from "../../handlers/list-xero-accounts.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListAccountsTool = CreateXeroTool(
   "list-accounts",
@@ -43,6 +44,7 @@ const ListAccountsTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingSettings
 );
 
 export default ListAccountsTool;

--- a/src/tools/list/list-aged-payables-by-contact.tool.ts
+++ b/src/tools/list/list-aged-payables-by-contact.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { formatAgedReportFilter } from "../../helpers/format-aged-report-filter.js";
 import { listXeroAgedPayablesByContact } from "../../handlers/list-aged-payables-by-contact.handler.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListAgedPayablesByContact = CreateXeroTool(
   "list-aged-payables-by-contact",
@@ -53,7 +54,8 @@ const ListAgedPayablesByContact = CreateXeroTool(
         }
       ],
     };
-  }
+  },
+  ToolScopes.accountingReportsRead
 );
 
 export default ListAgedPayablesByContact;

--- a/src/tools/list/list-aged-receivables-by-contact.tool.ts
+++ b/src/tools/list/list-aged-receivables-by-contact.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { listXeroAgedReceivablesByContact } from "../../handlers/list-aged-receivables-by-contact.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { formatAgedReportFilter } from "../../helpers/format-aged-report-filter.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListAgedReceivablesByContact = CreateXeroTool(
   "list-aged-receivables-by-contact",
@@ -53,7 +54,8 @@ const ListAgedReceivablesByContact = CreateXeroTool(
         }
       ],
     };
-  }
+  },
+  ToolScopes.accountingReportsRead
 );
 
 export default ListAgedReceivablesByContact;

--- a/src/tools/list/list-bank-transactions.tool.ts
+++ b/src/tools/list/list-bank-transactions.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { listXeroBankTransactions } from "../../handlers/list-xero-bank-transactions.handler.js";
 import { formatLineItem } from "../../helpers/format-line-item.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListBankTransactionsTool = CreateXeroTool(
   "list-bank-transactions",
@@ -62,7 +63,8 @@ const ListBankTransactionsTool = CreateXeroTool(
         })) || [])
       ]
     };
-  }
+  },
+  ToolScopes.accountingTransactions
 );
 
 export default ListBankTransactionsTool;

--- a/src/tools/list/list-contact-groups.tool.ts
+++ b/src/tools/list/list-contact-groups.tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { listXeroContactGroups } from "../../handlers/list-xero-contact-groups.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListContactGroupsTool = CreateXeroTool(
   "list-contact-groups",
@@ -54,6 +55,7 @@ const ListContactGroupsTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingContacts
 );
 
 export default ListContactGroupsTool;

--- a/src/tools/list/list-contacts.tool.ts
+++ b/src/tools/list/list-contacts.tool.ts
@@ -1,6 +1,7 @@
 import { listXeroContacts } from "../../handlers/list-xero-contacts.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { z } from "zod";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListContactsTool = CreateXeroTool(
   "list-contacts",
@@ -77,6 +78,7 @@ const ListContactsTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingContacts
 );
 
 export default ListContactsTool;

--- a/src/tools/list/list-credit-notes.tool.ts
+++ b/src/tools/list/list-credit-notes.tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { listXeroCreditNotes } from "../../handlers/list-xero-credit-notes.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListCreditNotesTool = CreateXeroTool(
   "list-credit-notes",
@@ -70,6 +71,7 @@ const ListCreditNotesTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default ListCreditNotesTool;

--- a/src/tools/list/list-invoices.tool.ts
+++ b/src/tools/list/list-invoices.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { listXeroInvoices } from "../../handlers/list-xero-invoices.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { formatLineItem } from "../../helpers/format-line-item.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListInvoicesTool = CreateXeroTool(
   "list-invoices",
@@ -91,6 +92,7 @@ const ListInvoicesTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default ListInvoicesTool;

--- a/src/tools/list/list-items.tool.ts
+++ b/src/tools/list/list-items.tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { listXeroItems } from "../../handlers/list-xero-items.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListItemsTool = CreateXeroTool(
   "list-items",
@@ -54,6 +55,7 @@ const ListItemsTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingSettings
 );
 
 export default ListItemsTool; 

--- a/src/tools/list/list-manual-journals.tool.ts
+++ b/src/tools/list/list-manual-journals.tool.ts
@@ -2,6 +2,7 @@ import { ManualJournal } from "xero-node";
 import { listXeroManualJournals } from "../../handlers/list-xero-manual-journals.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { z } from "zod";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListManualJournalsTool = CreateXeroTool(
   "list-manual-journals",
@@ -93,6 +94,7 @@ If they want the next page, call this tool again with the next page number, modi
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default ListManualJournalsTool;

--- a/src/tools/list/list-organisation-details.tool.ts
+++ b/src/tools/list/list-organisation-details.tool.ts
@@ -1,6 +1,7 @@
 import { listXeroOrganisationDetails } from "../../handlers/list-xero-organisation-details.handler.js";
 import { getExternalLink } from "../../helpers/get-external-link.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListOrganisationDetailsTool = CreateXeroTool(
   "list-organisation-details",
@@ -102,6 +103,7 @@ const ListOrganisationDetailsTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingSettings
 );
 
 export default ListOrganisationDetailsTool;

--- a/src/tools/list/list-payments.tool.ts
+++ b/src/tools/list/list-payments.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { listXeroPayments } from "../../handlers/list-xero-payments.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { Payment } from "xero-node";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 function paymentFormatter(payment: Payment): string {
   return [
@@ -87,6 +88,7 @@ const ListPaymentsTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default ListPaymentsTool;

--- a/src/tools/list/list-payroll-employee-leave-balances.tool.ts
+++ b/src/tools/list/list-payroll-employee-leave-balances.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { listXeroPayrollEmployeeLeaveBalances } from "../../handlers/list-xero-payroll-employee-leave-balances.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { EmployeeLeaveBalance } from "xero-node/dist/gen/model/payroll-nz/employeeLeaveBalance.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListPayrollEmployeeLeaveBalancesTool = CreateXeroTool(
   "list-payroll-employee-leave-balances",
@@ -44,6 +45,7 @@ const ListPayrollEmployeeLeaveBalancesTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.payrollEmployees
 );
 
 export default ListPayrollEmployeeLeaveBalancesTool;

--- a/src/tools/list/list-payroll-employee-leave-types.tool.ts
+++ b/src/tools/list/list-payroll-employee-leave-types.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { listXeroPayrollEmployeeLeaveTypes } from "../../handlers/list-xero-payroll-employee-leave-types.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { EmployeeLeaveType } from "xero-node/dist/gen/model/payroll-nz/employeeLeaveType.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListPayrollEmployeeLeaveTypesTool = CreateXeroTool(
   "list-payroll-employee-leave-types",
@@ -62,6 +63,7 @@ const ListPayrollEmployeeLeaveTypesTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.payrollEmployees
 );
 
 export default ListPayrollEmployeeLeaveTypesTool;

--- a/src/tools/list/list-payroll-employee-leave.tool.ts
+++ b/src/tools/list/list-payroll-employee-leave.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { listXeroPayrollEmployeeLeave } from "../../handlers/list-xero-payroll-employee-leave.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { EmployeeLeave } from "xero-node/dist/gen/model/payroll-nz/employeeLeave.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListPayrollEmployeeLeaveTool = CreateXeroTool(
   "list-payroll-employee-leave",
@@ -47,6 +48,7 @@ const ListPayrollEmployeeLeaveTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.payrollEmployees
 );
 
 export default ListPayrollEmployeeLeaveTool;

--- a/src/tools/list/list-payroll-employees.tool.ts
+++ b/src/tools/list/list-payroll-employees.tool.ts
@@ -1,6 +1,7 @@
 import { Employee } from "xero-node/dist/gen/model/payroll-nz/employee.js";
 import { listXeroPayrollEmployees } from "../../handlers/list-xero-payroll-employees.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListPayrollEmployeesTool = CreateXeroTool(
   "list-payroll-employees",
@@ -54,6 +55,7 @@ The response presents a complete overview of all staff currently registered in y
       ],
     };
   },
+  ToolScopes.payrollEmployees
 );
 
 export default ListPayrollEmployeesTool;

--- a/src/tools/list/list-payroll-leave-periods.tool.ts
+++ b/src/tools/list/list-payroll-leave-periods.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { listXeroPayrollLeavePeriods } from "../../handlers/list-xero-payroll-leave-periods.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { LeavePeriod } from "xero-node/dist/gen/model/payroll-nz/leavePeriod.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListPayrollLeavePeriodsToolTool = CreateXeroTool(
   "list-payroll-leave-periods",
@@ -50,6 +51,7 @@ const ListPayrollLeavePeriodsToolTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.payrollEmployees
 );
 
 export default ListPayrollLeavePeriodsToolTool;

--- a/src/tools/list/list-payroll-leave-types.tool.ts
+++ b/src/tools/list/list-payroll-leave-types.tool.ts
@@ -1,6 +1,7 @@
 import { listXeroPayrollLeaveTypes } from "../../handlers/list-xero-payroll-leave-types.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { LeaveType } from "xero-node/dist/gen/model/payroll-nz/leaveType.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListPayrollLeaveTypesTool = CreateXeroTool(
   "list-payroll-leave-types",
@@ -44,6 +45,7 @@ const ListPayrollLeaveTypesTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.payrollEmployees
 );
 
 export default ListPayrollLeaveTypesTool;

--- a/src/tools/list/list-payroll-timesheets.tool.ts
+++ b/src/tools/list/list-payroll-timesheets.tool.ts
@@ -4,6 +4,7 @@ import {
   listXeroPayrollTimesheets,
 } from "../../handlers/list-xero-timesheets.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListPayrollTimesheetsTool = CreateXeroTool(
   "list-timesheets",
@@ -48,6 +49,7 @@ This retrieves comprehensive timesheet details including timesheet IDs, employee
       ],
     };
   },
+  ToolScopes.payrollTimesheets
 );
 
 export default ListPayrollTimesheetsTool;

--- a/src/tools/list/list-profit-and-loss.tool.ts
+++ b/src/tools/list/list-profit-and-loss.tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { listXeroProfitAndLoss } from "../../handlers/list-xero-profit-and-loss.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListProfitAndLossTool = CreateXeroTool(
   "list-profit-and-loss",
@@ -57,6 +58,7 @@ const ListProfitAndLossTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingReportsRead
 );
 
 export default ListProfitAndLossTool; 

--- a/src/tools/list/list-quotes.tool.ts
+++ b/src/tools/list/list-quotes.tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { listXeroQuotes } from "../../handlers/list-xero-quotes.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListQuotesTool = CreateXeroTool(
   "list-quotes",
@@ -72,6 +73,7 @@ const ListQuotesTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default ListQuotesTool;

--- a/src/tools/list/list-report-balance-sheet.tool.ts
+++ b/src/tools/list/list-report-balance-sheet.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { listXeroReportBalanceSheet } from "../../handlers/list-xero-report-balance-sheet.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { ListReportBalanceSheetParams } from "../../types/list-report-balance-sheet-params.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListReportBalanceSheetTool = CreateXeroTool(
   "list-report-balance-sheet",
@@ -44,7 +45,8 @@ const ListReportBalanceSheetTool = CreateXeroTool(
         },
       ],
     };
-  }
+  },
+  ToolScopes.accountingReportsRead
 );
 
 export default ListReportBalanceSheetTool;

--- a/src/tools/list/list-tax-rates.tool.ts
+++ b/src/tools/list/list-tax-rates.tool.ts
@@ -1,5 +1,6 @@
 import { listXeroTaxRates } from "../../handlers/list-xero-tax-rates.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListTaxRatesTool = CreateXeroTool(
   "list-tax-rates",
@@ -56,6 +57,7 @@ const ListTaxRatesTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingSettings
 );
 
 export default ListTaxRatesTool;

--- a/src/tools/list/list-tracking-categories.tool.ts
+++ b/src/tools/list/list-tracking-categories.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { listXeroTrackingCategories } from "../../handlers/list-xero-tracking-categories.handler.js";
 import { formatTrackingOption } from "../../helpers/format-tracking-option.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListTrackingCategoriesTool = CreateXeroTool(
   "list-tracking-categories",
@@ -43,7 +44,8 @@ const ListTrackingCategoriesTool = CreateXeroTool(
         })) || [])
       ]
     };
-  }
+  },
+  ToolScopes.accountingSettings
 );
 
 export default ListTrackingCategoriesTool;

--- a/src/tools/list/list-trial-balance.tool.ts
+++ b/src/tools/list/list-trial-balance.tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { listXeroTrialBalance } from "../../handlers/list-xero-trial-balance.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ListTrialBalanceTool = CreateXeroTool(
   "list-trial-balance",
@@ -45,6 +46,7 @@ const ListTrialBalanceTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingReportsRead
 );
 
 export default ListTrialBalanceTool; 

--- a/src/tools/tool-factory.ts
+++ b/src/tools/tool-factory.ts
@@ -1,26 +1,70 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
 
+import {
+  getConfiguredScopes,
+  isCustomConnectionsAuthMode,
+  scopesSatisfyTool,
+} from "../helpers/scopes.js";
+import { ToolDefinition } from "../types/tool-definition.js";
 import { CreateTools } from "./create/index.js";
 import { DeleteTools } from "./delete/index.js";
 import { GetTools } from "./get/index.js";
 import { ListTools } from "./list/index.js";
 import { UpdateTools } from "./update/index.js";
 
-export function ToolFactory(server: McpServer) {
+const SCOPE_FILTER_LOG_ENV = "XERO_MCP_LOG_SCOPE_FILTERING";
 
-  DeleteTools.map((tool) => tool()).forEach((tool) =>
-    server.tool(tool.name, tool.description, tool.schema, tool.handler),
-  );
-  GetTools.map((tool) => tool()).forEach((tool) =>
-    server.tool(tool.name, tool.description, tool.schema, tool.handler),
-  );
-  CreateTools.map((tool) => tool()).forEach((tool) =>
-    server.tool(tool.name, tool.description, tool.schema, tool.handler),
-  );
-  ListTools.map((tool) => tool()).forEach((tool) =>
-    server.tool(tool.name, tool.description, tool.schema, tool.handler),
-  );
-  UpdateTools.map((tool) => tool()).forEach((tool) =>
-    server.tool(tool.name, tool.description, tool.schema, tool.handler),
-  );
+function registerTools(
+  server: McpServer,
+  factories: Array<() => ToolDefinition<ZodRawShapeCompat>>,
+  configuredScopes: Set<string>,
+  filterByScopes: boolean,
+): { registered: number; skipped: number } {
+  let registered = 0;
+  let skipped = 0;
+  for (const factory of factories) {
+    const tool = factory();
+    if (filterByScopes && !scopesSatisfyTool(configuredScopes, tool.requiredScopes)) {
+      skipped++;
+      continue;
+    }
+    server.tool(tool.name, tool.description, tool.schema, tool.handler);
+    registered++;
+  }
+  return { registered, skipped };
+}
+
+export function ToolFactory(server: McpServer) {
+  const filterByScopes = isCustomConnectionsAuthMode();
+  const configuredScopes = filterByScopes ? getConfiguredScopes() : new Set<string>();
+
+  let totalRegistered = 0;
+  let totalSkipped = 0;
+  for (const list of [
+    DeleteTools,
+    GetTools,
+    CreateTools,
+    ListTools,
+    UpdateTools,
+  ]) {
+    const { registered, skipped } = registerTools(
+      server,
+      list,
+      configuredScopes,
+      filterByScopes,
+    );
+    totalRegistered += registered;
+    totalSkipped += skipped;
+  }
+
+  if (
+    filterByScopes &&
+    totalSkipped > 0 &&
+    process.env[SCOPE_FILTER_LOG_ENV]?.trim()
+  ) {
+    console.error(
+      `[xero-mcp-server] OAuth scope filtering: registered ${totalRegistered} tool(s), omitted ${totalSkipped}. Unset ${SCOPE_FILTER_LOG_ENV} to hide this message.`,
+    );
+  }
 }

--- a/src/tools/update/approve-payroll-timesheet.tool.ts
+++ b/src/tools/update/approve-payroll-timesheet.tool.ts
@@ -4,6 +4,7 @@ import {
   approveXeroPayrollTimesheet,
 } from "../../handlers/approve-xero-payroll-timesheet.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const ApprovePayrollTimesheetTool = CreateXeroTool(
   "approve-timesheet",
@@ -37,6 +38,7 @@ const ApprovePayrollTimesheetTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.payrollTimesheets
 );
 
 export default ApprovePayrollTimesheetTool;

--- a/src/tools/update/revert-payroll-timesheet.tool.ts
+++ b/src/tools/update/revert-payroll-timesheet.tool.ts
@@ -4,6 +4,7 @@ import {
   revertXeroPayrollTimesheet,
 } from "../../handlers/revert-xero-payroll-timesheet.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const RevertPayrollTimesheetTool = CreateXeroTool(
   "revert-timesheet",
@@ -37,6 +38,7 @@ const RevertPayrollTimesheetTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.payrollTimesheets
 );
 
 export default RevertPayrollTimesheetTool;

--- a/src/tools/update/update-bank-transaction.tool.ts
+++ b/src/tools/update/update-bank-transaction.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { updateXeroBankTransaction } from "../../handlers/update-xero-bank-transaction.handler.js";
 import { bankTransactionDeepLink } from "../../consts/deeplinks.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const lineItemSchema = z.object({
   description: z.string(),
@@ -73,7 +74,8 @@ const UpdateBankTransactionTool = CreateXeroTool(
         },
       ],
     };
-  }
+  },
+  ToolScopes.accountingTransactions
 );
 
 export default UpdateBankTransactionTool;

--- a/src/tools/update/update-contact.tool.ts
+++ b/src/tools/update/update-contact.tool.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { ensureError } from "../../helpers/ensure-error.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const UpdateContactTool = CreateXeroTool(
   "update-contact",
@@ -105,6 +106,7 @@ const UpdateContactTool = CreateXeroTool(
       };
     }
   },
+  ToolScopes.accountingContacts
 );
 
 export default UpdateContactTool;

--- a/src/tools/update/update-credit-note.tool.ts
+++ b/src/tools/update/update-credit-note.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { updateXeroCreditNote } from "../../handlers/update-xero-credit-note.handler.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const lineItemSchema = z.object({
   description: z.string(),
@@ -90,6 +91,7 @@ const UpdateCreditNoteTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default UpdateCreditNoteTool; 

--- a/src/tools/update/update-invoice.tool.ts
+++ b/src/tools/update/update-invoice.tool.ts
@@ -3,6 +3,7 @@ import { updateXeroInvoice } from "../../handlers/update-xero-invoice.handler.js
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { Invoice } from "xero-node";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const trackingSchema = z.object({
   name: z.string().describe("The name of the tracking category. Can be obtained from the list-tracking-categories tool"),
@@ -114,6 +115,7 @@ const UpdateInvoiceTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default UpdateInvoiceTool;

--- a/src/tools/update/update-item.tool.ts
+++ b/src/tools/update/update-item.tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { updateXeroItem } from "../../handlers/update-xero-item.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const purchaseDetailsSchema = z.object({
   unitPrice: z.number().optional(),
@@ -82,6 +83,7 @@ const UpdateItemTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingSettings
 );
 
 export default UpdateItemTool; 

--- a/src/tools/update/update-manual-journal-tool.ts
+++ b/src/tools/update/update-manual-journal-tool.ts
@@ -4,6 +4,7 @@ import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { ensureError } from "../../helpers/ensure-error.js";
 import { LineAmountTypes, ManualJournal } from "xero-node";
 import { updateXeroManualJournal } from "../../handlers/update-xero-manual-journal.handler.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const UpdateManualJournalTool = CreateXeroTool(
   "update-manual-journal",
@@ -119,6 +120,7 @@ const UpdateManualJournalTool = CreateXeroTool(
       };
     }
   },
+  ToolScopes.accountingTransactions
 );
 
 export default UpdateManualJournalTool;

--- a/src/tools/update/update-payroll-timesheet-add-line.tool.ts
+++ b/src/tools/update/update-payroll-timesheet-add-line.tool.ts
@@ -7,6 +7,7 @@ import {
   updateXeroPayrollTimesheetAddLine,
 } from "../../handlers/update-xero-payroll-timesheet-add-line.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const AddTimesheetLineTool = CreateXeroTool(
   "add-timesheet-line",
@@ -45,6 +46,7 @@ const AddTimesheetLineTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.payrollTimesheets
 );
 
 export default AddTimesheetLineTool;

--- a/src/tools/update/update-payroll-timesheet-update-line.tool.ts
+++ b/src/tools/update/update-payroll-timesheet-update-line.tool.ts
@@ -7,6 +7,7 @@ import {
   updateXeroPayrollTimesheetUpdateLine,
 } from "../../handlers/update-xero-payroll-timesheet-update-line.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const UpdatePayrollTimesheetLineTool = CreateXeroTool(
   "update-timesheet-line",
@@ -46,6 +47,7 @@ const UpdatePayrollTimesheetLineTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.payrollTimesheets
 );
 
 export default UpdatePayrollTimesheetLineTool;

--- a/src/tools/update/update-quote.tool.ts
+++ b/src/tools/update/update-quote.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { updateXeroQuote } from "../../handlers/update-xero-quote.handler.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const lineItemSchema = z.object({
   description: z.string(),
@@ -93,6 +94,7 @@ const UpdateQuoteTool = CreateXeroTool(
       ],
     };
   },
+  ToolScopes.accountingTransactions
 );
 
 export default UpdateQuoteTool; 

--- a/src/tools/update/update-tracking-category.tool.ts
+++ b/src/tools/update/update-tracking-category.tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { updateXeroTrackingCategory } from "../../handlers/update-xero-tracking-category.handler.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const UpdateTrackingCategoryTool = CreateXeroTool(
   "update-tracking-category",
@@ -34,7 +35,8 @@ const UpdateTrackingCategoryTool = CreateXeroTool(
         },
       ]
     };
-  }
+  },
+  ToolScopes.accountingSettings
 );
 
 export default UpdateTrackingCategoryTool;

--- a/src/tools/update/update-tracking-options.tool.ts
+++ b/src/tools/update/update-tracking-options.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { formatTrackingOption } from "../../helpers/format-tracking-option.js";
 import { updateXeroTrackingOption } from "../../handlers/update-xero-tracking-options.handler.js";
+import { ToolScopes } from "../../helpers/scopes.js";
 
 const trackingOptionSchema = z.object({
   trackingOptionId: z.string(),
@@ -40,7 +41,8 @@ const UpdateTrackingOptionsTool = CreateXeroTool(
         },
       ]
     };
-  }
+  },
+  ToolScopes.accountingSettings
 );
 
 export default UpdateTrackingOptionsTool;

--- a/src/types/tool-definition.ts
+++ b/src/types/tool-definition.ts
@@ -11,4 +11,6 @@ export interface ToolDefinition<
   description: string;
   schema: Args;
   handler: ToolCallback<Args>;
+  /** OAuth scopes required for this tool; empty = always register (when not in bearer-token mode). */
+  requiredScopes?: string[];
 }


### PR DESCRIPTION
**Relates to:** [#136](https://github.com/XeroAPI/xero-mcp-server/pull/136) — configurable `XERO_SCOPES` for custom connections.

This branch **extends** that idea so reduced scopes don’t leave payroll (or other) tools registered while the token would 403 them.

## What changed

| Area | Summary |
|------|---------|
| `src/helpers/scopes.ts` | Default scope string, `VALID_SCOPES` (warn on unknown, still sent to Xero), `getConfiguredScopes()` / `getConfiguredScopeString()`, `ToolScopes` groups for tools. |
| Tools | Each `CreateXeroTool(...)` passes `requiredScopes` (via `ToolScopes.*`). |
| `tool-factory.ts` | Registers a tool only if configured scopes include all `requiredScopes` **when using client id/secret**. **Bearer token mode:** no filtering (token scopes aren’t known here). |
| `xero-client.ts` | Token request uses `getConfiguredScopeString()` (same source as gating). |
| `src/index.ts` | `import "dotenv/config"` first so `XERO_SCOPES` is loaded before tool registration. |
| README | Default scopes link to `scopes.ts`, scope↔tool table, granular-vs-broad scope caveat, `XERO_MCP_LOG_SCOPE_FILTERING`. |
| `.env.example` | `XERO_SCOPES`, `XERO_CLIENT_BEARER_TOKEN`, optional logging var. |

## New / notable env vars

- `XERO_SCOPES` — optional; space-separated (same as #136).
- `XERO_MCP_LOG_SCOPE_FILTERING=1` — stderr summary of registered vs omitted tools (custom connections only).

## Reviewer checklist

- [ ] Payroll tools require `payroll.settings` + `payroll.employees` or `payroll.settings` + `payroll.timesheets` — matches how you expect custom connections to be configured.
- [ ] Acceptable that **granular** OAuth scope names (bearer-style) do **not** satisfy broad `ToolScopes` until we add an alias map (documented in README).
- [ ] `console.warn` / optional `console.error` only to **stderr** (stdio MCP safe).


