### PR TITLE
feat: add History & Notes tools for 5 entities

### DIFF
--- a/src/handlers/history-handler-factory.ts
+++ b/src/handlers/history-handler-factory.ts
@@ -1,0 +1,100 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { HistoryRecord, HistoryRecords } from "xero-node";
+
+type GetHistoryMethod = (
+  xeroTenantId: string,
+  entityId: string,
+  options?: { headers: { [name: string]: string } },
+) => Promise<{ response: unknown; body: HistoryRecords }>;
+
+type CreateHistoryMethod = (
+  xeroTenantId: string,
+  entityId: string,
+  historyRecords: HistoryRecords,
+  idempotencyKey?: string,
+  options?: { headers: { [name: string]: string } },
+) => Promise<{ response: unknown; body: HistoryRecords }>;
+
+export interface HistoryEntityConfig {
+  getMethod: GetHistoryMethod;
+  createMethod: CreateHistoryMethod;
+}
+
+/**
+ * Get history records for a Xero entity
+ */
+export async function getEntityHistory(
+  entityId: string,
+  config: HistoryEntityConfig,
+): Promise<XeroClientResponse<HistoryRecord[]>> {
+  try {
+    await xeroClient.authenticate();
+
+    const response = await config.getMethod.call(
+      xeroClient.accountingApi,
+      xeroClient.tenantId,
+      entityId,
+      getClientHeaders(),
+    );
+
+    return {
+      result: response.body.historyRecords ?? [],
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}
+
+/**
+ * Add a note to a Xero entity's history.
+ * Notes are immutable once created — they cannot be edited or deleted.
+ */
+export async function addEntityNote(
+  entityId: string,
+  note: string,
+  config: HistoryEntityConfig,
+): Promise<XeroClientResponse<HistoryRecord>> {
+  try {
+    await xeroClient.authenticate();
+
+    const historyRecords: HistoryRecords = {
+      historyRecords: [{ details: note }],
+    };
+
+    const response = await config.createMethod.call(
+      xeroClient.accountingApi,
+      xeroClient.tenantId,
+      entityId,
+      historyRecords,
+      undefined,
+      getClientHeaders(),
+    );
+
+    const created = response.body.historyRecords?.[0];
+
+    if (!created) {
+      throw new Error("Note creation failed — no record returned.");
+    }
+
+    return {
+      result: created,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/tools/history/index.ts
+++ b/src/tools/history/index.ts
@@ -1,0 +1,179 @@
+import { z } from "zod";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import {
+  getEntityHistory,
+  addEntityNote,
+  HistoryEntityConfig,
+} from "../../handlers/history-handler-factory.js";
+import { xeroClient } from "../../clients/xero-client.js";
+import { HistoryRecord } from "xero-node";
+
+interface HistoryEntityDefinition {
+  entity: string;
+  idParam: string;
+  idDescription: string;
+  config: HistoryEntityConfig;
+}
+
+const HISTORY_ENTITIES: HistoryEntityDefinition[] = [
+  {
+    entity: "invoice",
+    idParam: "invoiceID",
+    idDescription: "The Xero invoice ID.",
+    config: {
+      getMethod: xeroClient.accountingApi.getInvoiceHistory,
+      createMethod: xeroClient.accountingApi.createInvoiceHistory,
+    },
+  },
+  {
+    entity: "contact",
+    idParam: "contactID",
+    idDescription: "The Xero contact ID.",
+    config: {
+      getMethod: xeroClient.accountingApi.getContactHistory,
+      createMethod: xeroClient.accountingApi.createContactHistory,
+    },
+  },
+  {
+    entity: "credit-note",
+    idParam: "creditNoteID",
+    idDescription: "The Xero credit note ID.",
+    config: {
+      getMethod: xeroClient.accountingApi.getCreditNoteHistory,
+      createMethod: xeroClient.accountingApi.createCreditNoteHistory,
+    },
+  },
+  {
+    entity: "bank-transaction",
+    idParam: "bankTransactionID",
+    idDescription: "The Xero bank transaction ID.",
+    config: {
+      getMethod: xeroClient.accountingApi.getBankTransactionsHistory,
+      createMethod:
+        xeroClient.accountingApi.createBankTransactionHistoryRecord,
+    },
+  },
+  {
+    entity: "quote",
+    idParam: "quoteID",
+    idDescription: "The Xero quote ID.",
+    config: {
+      getMethod: xeroClient.accountingApi.getQuoteHistory,
+      createMethod: xeroClient.accountingApi.createQuoteHistory,
+    },
+  },
+];
+
+function formatHistoryRecord(record: HistoryRecord): string {
+  return [
+    record.dateUTC ? `Date: ${record.dateUTC}` : null,
+    record.user ? `User: ${record.user}` : null,
+    record.details ? `Details: ${record.details}` : null,
+    record.changes ? `Changes: ${record.changes}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function createGetHistoryTool(def: HistoryEntityDefinition) {
+  return CreateXeroTool(
+    `get-${def.entity}-history`,
+    `Retrieve the history (audit trail) for a specific ${def.entity} in Xero. Returns a list of history records including dates, users, details, and changes.`,
+    {
+      [def.idParam]: z.string().describe(def.idDescription),
+    },
+    async (params: Record<string, string>) => {
+      const entityId = params[def.idParam];
+      const response = await getEntityHistory(entityId, def.config);
+
+      if (response.isError) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error retrieving ${def.entity} history: ${response.error}`,
+            },
+          ],
+        };
+      }
+
+      const records = response.result;
+
+      if (records.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `No history found for ${def.entity}: ${entityId}`,
+            },
+          ],
+        };
+      }
+
+      const formatted = records.map(formatHistoryRecord).join("\n---\n");
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `History for ${def.entity} ${entityId} (${records.length} record${records.length === 1 ? "" : "s"}):\n\n${formatted}`,
+          },
+        ],
+      };
+    },
+  );
+}
+
+function createAddNoteTool(def: HistoryEntityDefinition) {
+  return CreateXeroTool(
+    `add-${def.entity}-note`,
+    `Add a note to a specific ${def.entity} in Xero. Notes appear in the entity's history/audit trail. WARNING: Notes are immutable — once created they cannot be edited or deleted.`,
+    {
+      [def.idParam]: z.string().describe(def.idDescription),
+      note: z
+        .string()
+        .describe(
+          "The note text to add. This is immutable and cannot be edited or deleted after creation.",
+        ),
+    },
+    async (params: Record<string, string>) => {
+      const entityId = params[def.idParam];
+      const { note } = params;
+      const response = await addEntityNote(entityId, note, def.config);
+
+      if (response.isError) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error adding note to ${def.entity}: ${response.error}`,
+            },
+          ],
+        };
+      }
+
+      const record = response.result;
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: [
+              `Note added to ${def.entity} ${entityId}.`,
+              record.dateUTC ? `Date: ${record.dateUTC}` : null,
+              record.user ? `User: ${record.user}` : null,
+              `Details: ${record.details}`,
+            ]
+              .filter(Boolean)
+              .join("\n"),
+          },
+        ],
+      };
+    },
+  );
+}
+
+export const HistoryTools = HISTORY_ENTITIES.flatMap((def) => [
+  createGetHistoryTool(def),
+  createAddNoteTool(def),
+]);

--- a/src/tools/tool-factory.ts
+++ b/src/tools/tool-factory.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CreateTools } from "./create/index.js";
 import { DeleteTools } from "./delete/index.js";
 import { GetTools } from "./get/index.js";
+import { HistoryTools } from "./history/index.js";
 import { ListTools } from "./list/index.js";
 import { UpdateTools } from "./update/index.js";
 
@@ -15,6 +16,9 @@ export function ToolFactory(server: McpServer) {
     server.tool(tool.name, tool.description, tool.schema, tool.handler),
   );
   CreateTools.map((tool) => tool()).forEach((tool) =>
+    server.tool(tool.name, tool.description, tool.schema, tool.handler),
+  );
+  HistoryTools.map((tool) => tool()).forEach((tool) =>
     server.tool(tool.name, tool.description, tool.schema, tool.handler),
   );
   ListTools.map((tool) => tool()).forEach((tool) =>


### PR DESCRIPTION
## Summary

Add get-history and add-note tools for Invoices, Contacts, CreditNotes, BankTransactions, and Quotes using a shared handler factory.

### New tools (10 total)

| Get History | Add Note |
|-------------|----------|
| `get-invoice-history` | `add-invoice-note` |
| `get-contact-history` | `add-contact-note` |
| `get-credit-note-history` | `add-credit-note-note` |
| `get-bank-transaction-history` | `add-bank-transaction-note` |
| `get-quote-history` | `add-quote-note` |

### Why

Accountants rely on History & Notes for recording payment confirmations on AP bills (e.g. "paid via Wise, ref XYZ") and as a lightweight audit trail. The Xero API supports this via a consistent pattern across entities, but no tools exist for it yet.

### Architecture

- **Handler factory** (`src/handlers/history-handler-factory.ts`) — shared `getEntityHistory()` and `addEntityNote()` functions that accept entity-specific SDK method references. Uses typed `xero-node` SDK methods (`getInvoiceHistory`, `createInvoiceHistory`, etc.) via `.call()` binding.
- **Tool definitions** (`src/tools/history/index.ts`) — `HISTORY_ENTITIES` config array drives `createGetHistoryTool()` and `createAddNoteTool()` factories using the existing `CreateXeroTool` helper pattern.
- **Registration** — `HistoryTools` added to `tool-factory.ts` following the existing category pattern.

### Key details

- Notes are **immutable** — once created, they cannot be edited or deleted. Tool descriptions warn about this.
- Uses Zod schemas for parameters, matching existing tool patterns.
- History records include: DateUTC, User, Details, Changes.
- No new dependencies required — uses existing `xero-node` SDK, `zod`, and `@modelcontextprotocol/sdk`.

### Files changed (3)

- `src/handlers/history-handler-factory.ts` (new) — shared handler logic
- `src/tools/history/index.ts` (new) — tool definitions for all 5 entities
- `src/tools/tool-factory.ts` (modified) — registers HistoryTools