### PR TITLE
Add advanced filters to list-bank-transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ payroll.timesheets
 - `list-tax-rates`: Retrieve a list of tax rates
 - `list-payments`: Retrieve a list of payments
 - `list-trial-balance`: Retrieve a trial balance report
-- `list-bank-transactions`: Retrieve a list of bank account transactions
+- `list-bank-transactions`: Retrieve a list of bank account transactions, with optional filters by bank account, contact, transaction id, type, status, date range, last-modified time, and a raw `where` escape hatch for predicates the dedicated filters can't express
 - `list-payroll-employees`: Retrieve a list of Payroll Employees
 - `list-report-balance-sheet`: Retrieve a balance sheet report
 - `list-payroll-employee-leave`: Retrieve a Payroll Employee's leave records

--- a/src/handlers/list-xero-bank-transactions.handler.ts
+++ b/src/handlers/list-xero-bank-transactions.handler.ts
@@ -4,42 +4,173 @@ import { getClientHeaders } from "../helpers/get-client-headers.js";
 import { XeroClientResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
+export interface ListBankTransactionsParams {
+  page?: number;
+  pageSize?: number;
+  bankAccountId?: string;
+  bankTransactionIds?: string[];
+  contactIds?: string[];
+  types?: string[];
+  statuses?: string[];
+  fromDate?: string;
+  toDate?: string;
+  where?: string;
+  order?: string;
+  modifiedAfter?: string;
+}
+
+const GUID_RE =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+class ValidationError extends Error {}
+
+function assertGuid(value: string, fieldName: string): void {
+  if (!GUID_RE.test(value)) {
+    throw new ValidationError(
+      `Invalid GUID for ${fieldName}: ${JSON.stringify(value)}. Expected format: 00000000-0000-0000-0000-000000000000.`,
+    );
+  }
+}
+
+function parseDate(
+  value: string,
+  fieldName: string,
+): { y: number; m: number; d: number } {
+  const match = DATE_RE.exec(value);
+  if (!match) {
+    throw new ValidationError(
+      `Invalid date for ${fieldName}: ${JSON.stringify(value)}. Expected format: YYYY-MM-DD.`,
+    );
+  }
+  const y = Number(match[1]);
+  const m = Number(match[2]);
+  const d = Number(match[3]);
+  // Round-trip check guards against e.g. 2024-02-31.
+  const probe = new Date(Date.UTC(y, m - 1, d));
+  if (
+    probe.getUTCFullYear() !== y ||
+    probe.getUTCMonth() !== m - 1 ||
+    probe.getUTCDate() !== d
+  ) {
+    throw new ValidationError(
+      `Invalid calendar date for ${fieldName}: ${JSON.stringify(value)}.`,
+    );
+  }
+  return { y, m, d };
+}
+
+function parseModifiedAfter(value: string): Date {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new ValidationError(
+      `Invalid modifiedAfter timestamp: ${JSON.stringify(value)}. Expected ISO-8601 (e.g. 2024-01-01T00:00:00Z).`,
+    );
+  }
+  return parsed;
+}
+
+function buildWhereClause(params: ListBankTransactionsParams): string | undefined {
+  const groups: string[] = [];
+
+  if (params.bankAccountId) {
+    assertGuid(params.bankAccountId, "bankAccountId");
+    groups.push(`BankAccount.AccountID==guid("${params.bankAccountId}")`);
+  }
+
+  if (params.bankTransactionIds?.length) {
+    params.bankTransactionIds.forEach((id, i) =>
+      assertGuid(id, `bankTransactionIds[${i}]`),
+    );
+    groups.push(
+      params.bankTransactionIds
+        .map((id) => `BankTransactionID==guid("${id}")`)
+        .join(" OR "),
+    );
+  }
+
+  if (params.contactIds?.length) {
+    params.contactIds.forEach((id, i) => assertGuid(id, `contactIds[${i}]`));
+    groups.push(
+      params.contactIds
+        .map((id) => `Contact.ContactID==guid("${id}")`)
+        .join(" OR "),
+    );
+  }
+
+  if (params.types?.length) {
+    groups.push(params.types.map((t) => `Type=="${t}"`).join(" OR "));
+  }
+
+  if (params.statuses?.length) {
+    groups.push(params.statuses.map((s) => `Status=="${s}"`).join(" OR "));
+  }
+
+  if (params.fromDate) {
+    const { y, m, d } = parseDate(params.fromDate, "fromDate");
+    groups.push(`Date>=DateTime(${y},${m},${d})`);
+  }
+
+  if (params.toDate) {
+    const { y, m, d } = parseDate(params.toDate, "toDate");
+    groups.push(`Date<=DateTime(${y},${m},${d})`);
+  }
+
+  if (params.where && params.where.trim().length > 0) {
+    groups.push(params.where);
+  }
+
+  if (groups.length === 0) return undefined;
+  return groups.map((g) => `(${g})`).join(" AND ");
+}
+
 async function getBankTransactions(
-  page: number,
-  bankAccountId?: string,
+  params: ListBankTransactionsParams,
+  whereClause: string | undefined,
+  ifModifiedSince: Date | undefined,
 ): Promise<BankTransaction[]> {
   await xeroClient.authenticate();
 
-  const response = await xeroClient.accountingApi.getBankTransactions(xeroClient.tenantId,
-      undefined, // ifModifiedSince
-      bankAccountId ? `BankAccount.AccountID=guid("${bankAccountId}")` : undefined, // where
-      "Date DESC", // order
-      page, // page
-      undefined, // unitdp
-      10, // pagesize
-      getClientHeaders()
+  const response = await xeroClient.accountingApi.getBankTransactions(
+    xeroClient.tenantId,
+    ifModifiedSince,
+    whereClause,
+    params.order ?? "Date DESC",
+    params.page ?? 1,
+    undefined, // unitdp
+    params.pageSize ?? 10,
+    getClientHeaders(),
   );
 
   return response.body.bankTransactions ?? [];
 }
 
 export async function listXeroBankTransactions(
-  page: number = 1,
-  bankAccountId?: string
+  params: ListBankTransactionsParams = {},
 ): Promise<XeroClientResponse<BankTransaction[]>> {
   try {
-    const bankTransactions = await getBankTransactions(page, bankAccountId);
+    const ifModifiedSince = params.modifiedAfter
+      ? parseModifiedAfter(params.modifiedAfter)
+      : undefined;
+    const whereClause = buildWhereClause(params);
+
+    const bankTransactions = await getBankTransactions(
+      params,
+      whereClause,
+      ifModifiedSince,
+    );
 
     return {
       result: bankTransactions,
       isError: false,
-      error: null
-    }
+      error: null,
+    };
   } catch (error) {
     return {
       result: null,
       isError: true,
-      error: formatError(error)
-    }
+      error:
+        error instanceof ValidationError ? error.message : formatError(error),
+    };
   }
 }

--- a/src/tools/list/list-bank-transactions.tool.ts
+++ b/src/tools/list/list-bank-transactions.tool.ts
@@ -3,29 +3,106 @@ import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { listXeroBankTransactions } from "../../handlers/list-xero-bank-transactions.handler.js";
 import { formatLineItem } from "../../helpers/format-line-item.js";
 
+const BANK_TRANSACTION_TYPES = [
+  "RECEIVE",
+  "RECEIVEOVERPAYMENT",
+  "RECEIVEPREPAYMENT",
+  "SPEND",
+  "SPENDOVERPAYMENT",
+  "SPENDPREPAYMENT",
+  "RECEIVETRANSFER",
+  "SPENDTRANSFER",
+] as const;
+
+const BANK_TRANSACTION_STATUSES = ["AUTHORISED", "DELETED", "VOIDED"] as const;
+
 const ListBankTransactionsTool = CreateXeroTool(
   "list-bank-transactions",
-  `List all bank transactions in Xero.
-  Ask the user if they want to see bank transactions for a specific bank account,
-  or to see all bank transactions before running.
-  Ask the user if they want the next page of quotes after running this tool if
-  10 bank transactions are returned.
-  If they do, call this tool again with the next page number and the bank account
-  if one was provided in the provided in the previous call.`,
+  `List bank transactions in Xero with optional advanced filtering.
+  Default behaviour (no args): page 1, ordered by Date DESC, page size 10.
+  Prefer dedicated filter params (bankAccountId, contactIds, bankTransactionIds, types, statuses, fromDate, toDate)
+  over the 'where' escape hatch. Use 'where' only when a predicate cannot be expressed with the dedicated params
+  (e.g. amount thresholds: "Total>1000", reconciliation status: "IsReconciled==true").
+  Dedicated filters and 'where' compose with AND.
+  Examples:
+    - { bankAccountId, fromDate: "2024-01-01", toDate: "2024-01-31" }
+    - { contactIds: ["..."], types: ["SPEND"], statuses: ["AUTHORISED"] }
+    - { where: "Total>1000 AND IsReconciled==false" }
+  If 'pageSize' results are returned, ask the user whether to fetch the next page; if so, call again with the
+  same filters and an incremented 'page'.`,
   {
-    page: z.number(),
-    bankAccountId: z.string().optional()
+    page: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("1-based page number. Defaults to 1."),
+    pageSize: z
+      .number()
+      .int()
+      .positive()
+      .max(100)
+      .optional()
+      .describe(
+        "Results per page (max 100). Defaults to 10. Increase only when you specifically need more rows in one call.",
+      ),
+    bankAccountId: z
+      .string()
+      .optional()
+      .describe("GUID of a single bank account to scope results to."),
+    bankTransactionIds: z
+      .array(z.string())
+      .optional()
+      .describe("Filter to specific bank transaction GUIDs (OR-matched)."),
+    contactIds: z
+      .array(z.string())
+      .optional()
+      .describe("Filter to transactions for any of these contact GUIDs (OR-matched)."),
+    types: z
+      .array(z.enum(BANK_TRANSACTION_TYPES))
+      .optional()
+      .describe("Filter by transaction type (OR-matched)."),
+    statuses: z
+      .array(z.enum(BANK_TRANSACTION_STATUSES))
+      .optional()
+      .describe("Filter by transaction status (OR-matched)."),
+    fromDate: z
+      .string()
+      .optional()
+      .describe("Inclusive lower bound on transaction Date, format YYYY-MM-DD."),
+    toDate: z
+      .string()
+      .optional()
+      .describe("Inclusive upper bound on transaction Date, format YYYY-MM-DD."),
+    where: z
+      .string()
+      .optional()
+      .describe(
+        "Raw Xero where-clause for predicates the dedicated filters cannot express. Combined with dedicated filters via AND.",
+      ),
+    order: z
+      .string()
+      .optional()
+      .describe(
+        'Xero order clause, e.g. "Date DESC" or "UpdatedDateUTC ASC". Invalid fields will be rejected by Xero. Defaults to "Date DESC".',
+      ),
+    modifiedAfter: z
+      .string()
+      .optional()
+      .describe(
+        "ISO-8601 timestamp (e.g. 2024-01-01T00:00:00Z). Only return transactions modified strictly after this time.",
+      ),
   },
-  async ({ bankAccountId, page }) => {
-    const response = await listXeroBankTransactions(page, bankAccountId);
+  async (params) => {
+    const response = await listXeroBankTransactions(params);
     if (response.isError) {
       return {
         content: [
           {
             type: "text" as const,
-            text: `Error listing bank transactions: ${response.error}`
-          }
-        ]
+            text: `Error listing bank transactions: ${response.error}`,
+          },
+        ],
       };
     }
 
@@ -35,7 +112,7 @@ const ListBankTransactionsTool = CreateXeroTool(
       content: [
         {
           type: "text" as const,
-          text: `Found ${bankTransactions?.length || 0} bank transactions:`
+          text: `Found ${bankTransactions?.length || 0} bank transactions:`,
         },
         ...(bankTransactions?.map((transaction) => ({
           type: "text" as const,


### PR DESCRIPTION
## Summary
- Add optional filter params to `list-bank-transactions`: `bankAccountId`, `bankTransactionIds`, `contactIds`, `types`, `statuses`, `fromDate`, `toDate`, `modifiedAfter`, `where`, `order`, `pageSize`. `page` is now optional and defaults to 1.
- Handler builds a Xero `where` clause from dedicated filters (OR within a group, AND between groups) and ANDs in any user-supplied `where` wrapped in parens, so a clause like `A OR B` cannot break the chain. `modifiedAfter` is parsed and passed as `If-Modified-Since`.
- GUIDs, dates (`YYYY-MM-DD` plus calendar round-trip), and `modifiedAfter` are validated at the handler boundary; invalid input returns a clean error message via the existing `XeroClientResponse` error path.
- Existing callers using only `page` and/or `bankAccountId` remain backward-compatible; no-arg behaviour is unchanged (page 1, `Date DESC`, page size 10).

## Test plan
Verified live against the Xero Demo Company:
- [x] no-arg call returns 10 rows
- [x] `page: 2` returns the next page
- [x] `bankAccountId` narrows to that account (every row matches)
- [x] `contactIds` + `fromDate` + `toDate` returns rows in range
- [x] `types: ["SPEND"]` returns only SPEND; `types: ["RECEIVE"]` returns only RECEIVE
- [x] `statuses: ["AUTHORISED"]` filter applied
- [x] `where: "Total>1000"` works alone; `where: "Total>99999999"` returns 0 rows (confirms filter is reaching Xero)
- [x] mixed dedicated + user `where` composes with AND
- [x] `modifiedAfter` passes through as `If-Modified-Since`
- [x] `pageSize: 50` returns 50 rows; `pageSize: 5, page: 2` returns 5 rows
- [x] `order: "Date ASC"` accepted
- [x] empty arrays (`contactIds: []`, `types: []`) treated as no filter
- [x] valid-but-unused bankAccountId GUID returns 0 rows (proves where composition is correct, not silently dropped)
- [x] invalid GUID, invalid date format (e.g. `2024/01/01`), invalid calendar date (e.g. `2024-02-31`), and invalid `modifiedAfter` each return a clear error and do not crash
- [x] `npm run lint` clean
- [x] `npm run build` clean