### PR TITLE
fix: pass standardLayout to fetchProfitAndLoss in list-profit-and-loss

### DIFF
--- a/src/handlers/list-xero-profit-and-loss.handler.ts
+++ b/src/handlers/list-xero-profit-and-loss.handler.ts
@@ -65,6 +65,7 @@ export async function listXeroProfitAndLoss(
       toDate,
       periods,
       timeframe,
+      standardLayout,
       paymentsOnly,
     );
 


### PR DESCRIPTION
## Summary
- Fixes #138
- `listXeroProfitAndLoss` was calling `fetchProfitAndLoss` with only 5 arguments, omitting `standardLayout`. That shifted `paymentsOnly` into the `standardLayout` positional slot, so `paymentsOnly` was never forwarded to the Xero SDK call to `getReportProfitAndLoss`.
- Pass `standardLayout` in its correct position so `paymentsOnly` actually reaches the API.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` succeeds (no new warnings)
- [ ] Manual verification by issue reporter: calling `list-profit-and-loss` with `paymentsOnly=true` on a cash-basis org now returns cash-basis figures distinct from the default accrual response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)