### PR TITLE
Format line item tracking values

### DIFF
--- a/src/helpers/__tests__/format-line-item.test.ts
+++ b/src/helpers/__tests__/format-line-item.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { LineItem } from "xero-node";
+import { formatLineItem } from "../format-line-item.js";
+
+describe("formatLineItem", () => {
+  it("formats tracking categories without object stringification", () => {
+    const lineItem = {
+      itemCode: "CONSULT",
+      description: "Consulting services",
+      tracking: [
+        {
+          name: "Project",
+          option: "Website Redesign",
+          trackingCategoryID: "category-1",
+          trackingOptionID: "option-1",
+        },
+        {
+          name: "Cost Centre",
+          option: "Marketing",
+          trackingCategoryID: "category-2",
+          trackingOptionID: "option-2",
+        },
+      ],
+      lineAmount: 120,
+    } as LineItem;
+
+    const result = formatLineItem(lineItem);
+
+    expect(result).toContain(
+      "Tracking: Category: Project, Category ID: category-1, Option: Website Redesign, Option ID: option-1; Category: Cost Centre, Category ID: category-2, Option: Marketing, Option ID: option-2",
+    );
+    expect(result).not.toContain("[object Object]");
+  });
+
+  it("omits tracking when there are no tracking categories", () => {
+    expect(
+      formatLineItem({ description: "No tracking" } as LineItem),
+    ).not.toContain("Tracking:");
+  });
+});

--- a/src/helpers/format-line-item.ts
+++ b/src/helpers/format-line-item.ts
@@ -1,6 +1,32 @@
 import { LineItem } from "xero-node";
 
+const formatTracking = (tracking: LineItem["tracking"]): string | undefined => {
+  if (!tracking?.length) {
+    return undefined;
+  }
+
+  return tracking
+    .map((trackingItem) =>
+      [
+        trackingItem.name ? `Category: ${trackingItem.name}` : undefined,
+        trackingItem.trackingCategoryID
+          ? `Category ID: ${trackingItem.trackingCategoryID}`
+          : undefined,
+        trackingItem.option ? `Option: ${trackingItem.option}` : undefined,
+        trackingItem.trackingOptionID
+          ? `Option ID: ${trackingItem.trackingOptionID}`
+          : undefined,
+      ]
+        .filter(Boolean)
+        .join(", "),
+    )
+    .filter(Boolean)
+    .join("; ");
+};
+
 export const formatLineItem = (lineItem: LineItem): string => {
+  const tracking = formatTracking(lineItem.tracking);
+
   return [
     `Item ID: ${lineItem.item}`,
     `Item Code: ${lineItem.itemCode}`,
@@ -9,7 +35,9 @@ export const formatLineItem = (lineItem: LineItem): string => {
     `Unit Amount: ${lineItem.unitAmount}`,
     `Account Code: ${lineItem.accountCode}`,
     `Tax Type: ${lineItem.taxType}`,
-    `Tracking: ${lineItem.tracking}`,
+    tracking ? `Tracking: ${tracking}` : undefined,
     `Line Amount: ${lineItem.lineAmount}`,
-  ].join("\n");
+  ]
+    .filter(Boolean)
+    .join("\n");
 };


### PR DESCRIPTION
## Summary
- format line item tracking entries as category/option text instead of relying on array stringification
- omit the tracking line when a line item has no tracking values
- add regression coverage to ensure tracking output does not contain `[object Object]`

Fixes #159.

## Tests
- `npm test`
- `npm run lint`