### PR TITLE
feat: support tracking categories on bank transactions

### DIFF
--- a/src/handlers/create-xero-bank-transaction.handler.ts
+++ b/src/handlers/create-xero-bank-transaction.handler.ts
@@ -1,6 +1,6 @@
 import { xeroClient } from "../clients/xero-client.js";
 import { XeroClientResponse } from "../types/tool-response.js";
-import { BankTransaction } from "xero-node";
+import { BankTransaction, LineItemTracking } from "xero-node";
 import { formatError } from "../helpers/format-error.js";
 import { getClientHeaders } from "../helpers/get-client-headers.js";
 
@@ -10,6 +10,7 @@ interface BankTransactionLineItem {
   unitAmount: number;
   accountCode: string;
   taxType: string;
+  tracking?: LineItemTracking[];
 }
 
 type BankTransactionType = "RECEIVE" | "SPEND";

--- a/src/handlers/create-xero-manual-journal.handler.ts
+++ b/src/handlers/create-xero-manual-journal.handler.ts
@@ -27,7 +27,7 @@ async function createManualJournal(
       accountCode: journalLine.accountCode,
       description: journalLine.description,
       taxType: journalLine.taxType,
-      // TODO: tracking can be added here
+      tracking: journalLine.tracking,
     })),
     date: date,
     lineAmountTypes: lineAmountTypes,

--- a/src/handlers/update-xero-bank-transaction.handler.ts
+++ b/src/handlers/update-xero-bank-transaction.handler.ts
@@ -2,7 +2,7 @@ import { xeroClient } from "../clients/xero-client.js";
 import { formatError } from "../helpers/format-error.js";
 import { getClientHeaders } from "../helpers/get-client-headers.js";
 import { XeroClientResponse } from "../types/tool-response.js";
-import { BankTransaction } from "xero-node";
+import { BankTransaction, LineItemTracking } from "xero-node";
 
 interface BankTransactionLineItem {
   description: string;
@@ -10,6 +10,7 @@ interface BankTransactionLineItem {
   unitAmount: number;
   accountCode: string;
   taxType: string;
+  tracking?: LineItemTracking[];
 }
 
 type BankTransactionType = "RECEIVE" | "SPEND";

--- a/src/handlers/update-xero-manual-journal.handler.ts
+++ b/src/handlers/update-xero-manual-journal.handler.ts
@@ -28,7 +28,7 @@ async function updateManualJournal(
       accountCode: journalLine.accountCode,
       description: journalLine.description, // Optional: description for the manual journal line
       taxType: journalLine.taxType, // Optional: tax type for the manual journal line
-      // TODO: tracking can be added here
+      tracking: journalLine.tracking, // Optional: up to 2 tracking categories per line
     })),
     date: date, // Optional: YYYY-MM-DD format
     lineAmountTypes: lineAmountTypes, // Optional: ManualJournal.LineAmountTypesEnum.EXCLUSIVE

--- a/src/helpers/__tests__/format-tracking.test.ts
+++ b/src/helpers/__tests__/format-tracking.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { TrackingCategory } from "xero-node";
+import { formatTracking } from "../format-tracking.js";
+
+describe("formatTracking", () => {
+  it("returns null when tracking is undefined", () => {
+    expect(formatTracking(undefined)).toBeNull();
+  });
+
+  it("returns null when tracking is an empty array", () => {
+    expect(formatTracking([])).toBeNull();
+  });
+
+  it("formats a single category/option pair", () => {
+    const tracking: TrackingCategory[] = [{ name: "Property", option: "CG" }];
+    expect(formatTracking(tracking)).toBe("Property/CG");
+  });
+
+  it("formats multiple category/option pairs comma-separated", () => {
+    const tracking: TrackingCategory[] = [
+      { name: "Property", option: "CG" },
+      { name: "Region", option: "East" },
+    ];
+    expect(formatTracking(tracking)).toBe("Property/CG, Region/East");
+  });
+
+  it("renders readable text rather than [object Object]", () => {
+    const tracking: TrackingCategory[] = [{ name: "Property", option: "ES" }];
+    expect(formatTracking(tracking)).not.toContain("[object Object]");
+  });
+
+  it("falls back to the category name when option is missing", () => {
+    const tracking: TrackingCategory[] = [{ name: "Property" }];
+    expect(formatTracking(tracking)).toBe("Property");
+  });
+
+  it("skips entries that have neither name nor option", () => {
+    const tracking: TrackingCategory[] = [
+      { name: "Property", option: "CG" },
+      {},
+    ];
+    expect(formatTracking(tracking)).toBe("Property/CG");
+  });
+
+  it("returns null when every entry is empty", () => {
+    const tracking: TrackingCategory[] = [{}, {}];
+    expect(formatTracking(tracking)).toBeNull();
+  });
+});

--- a/src/helpers/__tests__/tracking-schema.test.ts
+++ b/src/helpers/__tests__/tracking-schema.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { trackingSchema } from "../tracking-schema.js";
+
+describe("trackingSchema", () => {
+  it("accepts a category name and option with no tracking category ID", () => {
+    expect(trackingSchema.parse({ name: "Property", option: "CG" })).toEqual({
+      name: "Property",
+      option: "CG",
+    });
+  });
+
+  it("accepts an explicit tracking category ID", () => {
+    const tracking = {
+      name: "Property",
+      option: "CG",
+      trackingCategoryID: "9c8f5f6d-8b0e-4a6f-9d2c-1e3a5b7c9d11",
+    };
+
+    expect(trackingSchema.parse(tracking)).toEqual(tracking);
+  });
+
+  it("rejects a tracking entry with no category name", () => {
+    expect(() => trackingSchema.parse({ option: "CG" })).toThrow();
+  });
+
+  it("rejects a tracking entry with no option", () => {
+    expect(() => trackingSchema.parse({ name: "Property" })).toThrow();
+  });
+});

--- a/src/helpers/format-tracking.ts
+++ b/src/helpers/format-tracking.ts
@@ -1,0 +1,28 @@
+import { TrackingCategory } from "xero-node";
+
+/**
+ * Format a line's tracking categories as readable `category/option` text.
+ *
+ * Manual journal lines (and other line types) can carry up to two tracking
+ * categories. Printing the raw array yields `[object Object]`, so this renders
+ * each entry as `name/option` (or just `name` when the option is absent) and
+ * joins multiple entries with commas.
+ *
+ * @returns the formatted string, or `null` when there is nothing to show so
+ * callers can omit the line cleanly.
+ */
+export const formatTracking = (
+  tracking?: TrackingCategory[],
+): string | null => {
+  if (!tracking || tracking.length === 0) {
+    return null;
+  }
+
+  const formatted = tracking
+    .map((category) =>
+      [category.name, category.option].filter(Boolean).join("/"),
+    )
+    .filter((entry) => entry.length > 0);
+
+  return formatted.length > 0 ? formatted.join(", ") : null;
+};

--- a/src/helpers/tracking-schema.ts
+++ b/src/helpers/tracking-schema.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+/**
+ * Shared Zod schema for a single tracking category/option pair on a line.
+ * Used by invoice and manual journal tools so the shape stays consistent.
+ * Both the Xero `LineItemTracking` and `TrackingCategory` types accept these
+ * three fields, so the same schema works on invoice lines and manual journal lines.
+ */
+export const trackingSchema = z.object({
+  name: z
+    .string()
+    .describe(
+      "The name of the tracking category. Can be obtained from the list-tracking-categories tool",
+    ),
+  option: z
+    .string()
+    .describe(
+      "The name of the tracking option. Can be obtained from the list-tracking-categories tool",
+    ),
+  trackingCategoryID: z
+    .string()
+    .describe(
+      "The ID of the tracking category. \
+    Can be obtained from the list-tracking-categories tool",
+    ),
+});

--- a/src/helpers/tracking-schema.ts
+++ b/src/helpers/tracking-schema.ts
@@ -20,7 +20,7 @@ export const trackingSchema = z.object({
   trackingCategoryID: z
     .string()
     .describe(
-      "The ID of the tracking category. \
-    Can be obtained from the list-tracking-categories tool",
-    ),
+      "The ID of the tracking category. Optional - Xero resolves the category and option from the name and option fields, so omit it rather than calling the list-tracking-categories tool to look one up.",
+    )
+    .optional(),
 });

--- a/src/tools/create/create-bank-transaction.tool.ts
+++ b/src/tools/create/create-bank-transaction.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { createXeroBankTransaction } from "../../handlers/create-xero-bank-transaction.handler.js";
 import { bankTransactionDeepLink } from "../../consts/deeplinks.js";
+import { trackingSchema } from "../../helpers/tracking-schema.js";
 
 const lineItemSchema = z.object({
   description: z.string(),
@@ -9,6 +10,15 @@ const lineItemSchema = z.object({
   unitAmount: z.number(),
   accountCode: z.string(),
   taxType: z.string(),
+  tracking: z
+    .array(trackingSchema)
+    .max(2)
+    .optional()
+    .describe(
+      "Up to 2 tracking categories and options can be added to the line item. \
+      Can be obtained from the list-tracking-categories tool. \
+      Only use if prompted by the user.",
+    ),
 });
 
 const CreateBankTransactionTool = CreateXeroTool(

--- a/src/tools/create/create-invoice.tool.ts
+++ b/src/tools/create/create-invoice.tool.ts
@@ -2,14 +2,8 @@ import { z } from "zod";
 import { createXeroInvoice } from "../../handlers/create-xero-invoice.handler.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { trackingSchema } from "../../helpers/tracking-schema.js";
 import { Invoice } from "xero-node";
-
-const trackingSchema = z.object({
-  name: z.string().describe("The name of the tracking category. Can be obtained from the list-tracking-categories tool"),
-  option: z.string().describe("The name of the tracking option. Can be obtained from the list-tracking-categories tool"),
-  trackingCategoryID: z.string().describe("The ID of the tracking category. \
-    Can be obtained from the list-tracking-categories tool"),
-});
 
 const lineItemSchema = z.object({
   description: z.string().describe("The description of the line item"),

--- a/src/tools/create/create-manual-journal.tool.ts
+++ b/src/tools/create/create-manual-journal.tool.ts
@@ -3,6 +3,8 @@ import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { createXeroManualJournal } from "../../handlers/create-xero-manual-journal.handler.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { ensureError } from "../../helpers/ensure-error.js";
+import { trackingSchema } from "../../helpers/tracking-schema.js";
+import { formatTracking } from "../../helpers/format-tracking.js";
 import { LineAmountTypes, ManualJournal } from "xero-node";
 
 const CreateManualJournalTool = CreateXeroTool(
@@ -33,7 +35,15 @@ const CreateManualJournalTool = CreateXeroTool(
             .string()
             .optional()
             .describe("Optional tax type for the manual journal line"),
-          // TODO: TODO: tracking can be added here
+          tracking: z
+            .array(trackingSchema)
+            .max(2)
+            .optional()
+            .describe(
+              "Up to 2 tracking categories and options can be added to the journal line. \
+              Can be obtained from the list-tracking-categories tool. \
+              Only use if prompted by the user.",
+            ),
         }),
       )
       .describe(
@@ -105,25 +115,29 @@ const CreateManualJournalTool = CreateXeroTool(
                 ? `Status: ${manualJournal.status}`
                 : "No status",
               manualJournal.journalLines
-                ? manualJournal.journalLines.map((line) => ({
-                    type: "text" as const,
-                    text: [
-                      `Line Amount: ${line.lineAmount}`,
-                      line.accountCode
-                        ? `Account Code: ${line.accountCode}`
-                        : "No account code",
-                      line.description
-                        ? `Description: ${line.description}`
-                        : "No description",
-                      line.taxType
-                        ? `Tax Type: ${line.taxType}`
-                        : "No tax type",
-                      `Tax Amount: ${line.taxAmount}`,
-                    ]
-                      .filter(Boolean)
-                      .join("\n"),
-                  }))
-                : [{ type: "text" as const, text: "No journal lines" }],
+                ? manualJournal.journalLines
+                    .map((line) =>
+                      [
+                        `Line Amount: ${line.lineAmount}`,
+                        line.accountCode
+                          ? `Account Code: ${line.accountCode}`
+                          : "No account code",
+                        line.description
+                          ? `Description: ${line.description}`
+                          : "No description",
+                        line.taxType
+                          ? `Tax Type: ${line.taxType}`
+                          : "No tax type",
+                        `Tax Amount: ${line.taxAmount}`,
+                        formatTracking(line.tracking)
+                          ? `Tracking: ${formatTracking(line.tracking)}`
+                          : null,
+                      ]
+                        .filter(Boolean)
+                        .join("\n"),
+                    )
+                    .join("\n\n")
+                : "No journal lines",
               `Show on Cash Basis Reports: ${manualJournal.showOnCashBasisReports}`,
               deepLink ? `Link to view: ${deepLink}` : null,
             ]

--- a/src/tools/list/list-manual-journals.tool.ts
+++ b/src/tools/list/list-manual-journals.tool.ts
@@ -1,6 +1,7 @@
 import { ManualJournal } from "xero-node";
 import { listXeroManualJournals } from "../../handlers/list-xero-manual-journals.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatTracking } from "../../helpers/format-tracking.js";
 import { z } from "zod";
 
 const ListManualJournalsTool = CreateXeroTool(
@@ -71,6 +72,9 @@ If they want the next page, call this tool again with the next page number, modi
                       : "No description",
                     line.taxType ? `Tax Type: ${line.taxType}` : "No tax type",
                     `Tax Amount: ${line.taxAmount}`,
+                    formatTracking(line.tracking)
+                      ? `Tracking: ${formatTracking(line.tracking)}`
+                      : null,
                   ]
                     .filter(Boolean)
                     .join("\n")

--- a/src/tools/update/update-bank-transaction.tool.ts
+++ b/src/tools/update/update-bank-transaction.tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { updateXeroBankTransaction } from "../../handlers/update-xero-bank-transaction.handler.js";
 import { bankTransactionDeepLink } from "../../consts/deeplinks.js";
+import { trackingSchema } from "../../helpers/tracking-schema.js";
 
 const lineItemSchema = z.object({
   description: z.string(),
@@ -9,6 +10,15 @@ const lineItemSchema = z.object({
   unitAmount: z.number(),
   accountCode: z.string(),
   taxType: z.string(),
+  tracking: z
+    .array(trackingSchema)
+    .max(2)
+    .optional()
+    .describe(
+      "Up to 2 tracking categories and options can be added to the line item. \
+      Can be obtained from the list-tracking-categories tool. \
+      Only use if prompted by the user.",
+    ),
 });
 
 const UpdateBankTransactionTool = CreateXeroTool(

--- a/src/tools/update/update-invoice.tool.ts
+++ b/src/tools/update/update-invoice.tool.ts
@@ -2,14 +2,8 @@ import { z } from "zod";
 import { updateXeroInvoice } from "../../handlers/update-xero-invoice.handler.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { trackingSchema } from "../../helpers/tracking-schema.js";
 import { Invoice } from "xero-node";
-
-const trackingSchema = z.object({
-  name: z.string().describe("The name of the tracking category. Can be obtained from the list-tracking-categories tool"),
-  option: z.string().describe("The name of the tracking option. Can be obtained from the list-tracking-categories tool"),
-  trackingCategoryID: z.string().describe("The ID of the tracking category. \
-    Can be obtained from the list-tracking-categories tool"),
-});
 
 const lineItemSchema = z.object({
   description: z.string().describe("The description of the line item"),

--- a/src/tools/update/update-manual-journal-tool.ts
+++ b/src/tools/update/update-manual-journal-tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { ensureError } from "../../helpers/ensure-error.js";
+import { trackingSchema } from "../../helpers/tracking-schema.js";
 import { LineAmountTypes, ManualJournal } from "xero-node";
 import { updateXeroManualJournal } from "../../handlers/update-xero-manual-journal.handler.js";
 
@@ -31,7 +32,15 @@ const UpdateManualJournalTool = CreateXeroTool(
             .string()
             .optional()
             .describe("Optional tax type for the manual journal line"),
-          // TODO: TODO: tracking can be added here
+          tracking: z
+            .array(trackingSchema)
+            .max(2)
+            .optional()
+            .describe(
+              "Up to 2 tracking categories and options can be added to the journal line. \
+              Can be obtained from the list-tracking-categories tool. \
+              Only use if prompted by the user.",
+            ),
         }),
       )
       .describe(


### PR DESCRIPTION
## Problem

Bank transaction lines cannot carry Xero **tracking categories** on the write path. The create/update tool line schemas have no `tracking` field, and the handlers' local `BankTransactionLineItem` interface omits it, so any tracking is dropped before reaching the SDK — even though `BankTransaction.lineItems` is `Array<LineItem>` and `LineItem` supports `tracking` (invoices already prove the SDK forwards it).

## Changes

- Add `tracking` (max 2 per line) to the `create-bank-transaction` and `update-bank-transaction` line schemas, reusing the shared `trackingSchema` helper.
- Add `tracking?: LineItemTracking[]` to the `BankTransactionLineItem` interface in both handlers so it forwards to the Xero API (the handlers already pass `lineItems` straight through).

## Scope / relationship to other PRs

- **Stacked on #180** (manual-journal tracking), which introduces the shared `trackingSchema` helper this PR reuses. `src/helpers/tracking-schema.ts` and its test therefore appear in this diff; they carry the same change as #180 (`trackingCategoryID` optional), applied here so this PR is green standalone. Bank-transaction lines pick it up for free: `tracking: [{ name, option }]` is now accepted without a GUID. Until #180 merges, this PR's diff includes those commits; it will reduce to just the bank-transaction changes once #180 lands.
- **Read display is handled by #178.** `list-bank-transactions` renders line-item tracking via the shared `formatLineItem` helper, whose `[object Object]` rendering is fixed in #178. This PR deliberately does **not** touch `format-line-item.ts`, so there is no collision — but #178 is what makes the tracking *visible* on read.

## Verification

Verified end-to-end against a real Xero tenant (with #178 applied for display): created a £0.01 SPEND bank transaction with tracking on its line, listed it back and confirmed the tracking renders as readable text (no `[object Object]`), then deleted the transaction. `npm run build`, `npm run lint`, and `npm test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
