### PR TITLE
fix: map manual journal lineAmountTypes to valid Xero enum values

### DIFF
--- a/src/helpers/__tests__/map-line-amount-type.test.ts
+++ b/src/helpers/__tests__/map-line-amount-type.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { LineAmountTypes } from "xero-node";
+import { mapLineAmountType } from "../map-line-amount-type.js";
+
+describe("mapLineAmountType", () => {
+  it("maps EXCLUSIVE to the Xero Exclusive value", () => {
+    expect(mapLineAmountType("EXCLUSIVE")).toBe(LineAmountTypes.Exclusive);
+  });
+
+  it("maps INCLUSIVE to the Xero Inclusive value", () => {
+    expect(mapLineAmountType("INCLUSIVE")).toBe(LineAmountTypes.Inclusive);
+  });
+
+  it("maps NO_TAX to the Xero NoTax value", () => {
+    expect(mapLineAmountType("NO_TAX")).toBe(LineAmountTypes.NoTax);
+  });
+
+  it("returns undefined when no value is supplied", () => {
+    expect(mapLineAmountType(undefined)).toBeUndefined();
+  });
+
+  it("produces the real Xero string values, not the tool input strings", () => {
+    // Regression guard: a `as LineAmountTypes` cast used to pass the raw tool
+    // string through, sending an invalid value Xero rejects.
+    expect(mapLineAmountType("NO_TAX")).toBe("NoTax");
+    expect(mapLineAmountType("EXCLUSIVE")).toBe("Exclusive");
+    expect(mapLineAmountType("INCLUSIVE")).toBe("Inclusive");
+    expect(mapLineAmountType("NO_TAX")).not.toBe("NO_TAX");
+  });
+});

--- a/src/helpers/map-line-amount-type.ts
+++ b/src/helpers/map-line-amount-type.ts
@@ -1,0 +1,35 @@
+import { LineAmountTypes } from "xero-node";
+
+/**
+ * Friendly line-amount-type values exposed on the MCP tool schemas.
+ *
+ * These are the upper-snake-case names a caller passes to the manual journal
+ * tools. They are NOT the values the Xero API expects.
+ */
+export type LineAmountTypeInput = "EXCLUSIVE" | "INCLUSIVE" | "NO_TAX";
+
+/**
+ * Map a friendly tool input value to the Xero SDK `LineAmountTypes` enum.
+ *
+ * The Xero API only accepts `Exclusive` / `Inclusive` / `NoTax`. Passing the
+ * raw tool strings (`EXCLUSIVE` / `INCLUSIVE` / `NO_TAX`) straight through —
+ * which a `as LineAmountTypes` cast silently allowed — sends an invalid value
+ * and Xero rejects the whole request. This translates them correctly.
+ *
+ * @returns the matching `LineAmountTypes`, or `undefined` when no value was
+ * supplied (Xero then defaults the journal to `NoTax`).
+ */
+export const mapLineAmountType = (
+  input?: LineAmountTypeInput,
+): LineAmountTypes | undefined => {
+  switch (input) {
+    case "EXCLUSIVE":
+      return LineAmountTypes.Exclusive;
+    case "INCLUSIVE":
+      return LineAmountTypes.Inclusive;
+    case "NO_TAX":
+      return LineAmountTypes.NoTax;
+    default:
+      return undefined;
+  }
+};

--- a/src/tools/create/create-manual-journal.tool.ts
+++ b/src/tools/create/create-manual-journal.tool.ts
@@ -3,7 +3,8 @@ import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { createXeroManualJournal } from "../../handlers/create-xero-manual-journal.handler.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { ensureError } from "../../helpers/ensure-error.js";
-import { LineAmountTypes, ManualJournal } from "xero-node";
+import { mapLineAmountType } from "../../helpers/map-line-amount-type.js";
+import { ManualJournal } from "xero-node";
 
 const CreateManualJournalTool = CreateXeroTool(
   "create-manual-journal",
@@ -69,7 +70,7 @@ const CreateManualJournalTool = CreateXeroTool(
         args.narration,
         args.manualJournalLines,
         args.date,
-        args.lineAmountTypes as LineAmountTypes | undefined,
+        mapLineAmountType(args.lineAmountTypes),
         args.status as ManualJournal.StatusEnum | undefined,
         args.url,
         args.showOnCashBasisReports,

--- a/src/tools/update/update-manual-journal-tool.ts
+++ b/src/tools/update/update-manual-journal-tool.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
 import { ensureError } from "../../helpers/ensure-error.js";
-import { LineAmountTypes, ManualJournal } from "xero-node";
+import { mapLineAmountType } from "../../helpers/map-line-amount-type.js";
+import { ManualJournal } from "xero-node";
 import { updateXeroManualJournal } from "../../handlers/update-xero-manual-journal.handler.js";
 
 const UpdateManualJournalTool = CreateXeroTool(
@@ -68,7 +69,7 @@ const UpdateManualJournalTool = CreateXeroTool(
         args.manualJournalID,
         args.manualJournalLines,
         args.date,
-        args.lineAmountTypes as LineAmountTypes | undefined,
+        mapLineAmountType(args.lineAmountTypes),
         args.status as ManualJournal.StatusEnum | undefined,
         args.url,
         args.showOnCashBasisReports,


### PR DESCRIPTION
## Problem

`create-manual-journal` and `update-manual-journal` expose `lineAmountTypes` as `EXCLUSIVE` / `INCLUSIVE` / `NO_TAX` and pass the raw string straight to the SDK with an `as LineAmountTypes` cast:

```ts
args.lineAmountTypes as LineAmountTypes | undefined,
```

But Xero's `LineAmountTypes` enum only accepts `Exclusive` / `Inclusive` / `NoTax`, and `xero-node` serialises enum values verbatim. So whenever a caller sets `lineAmountTypes` explicitly, an invalid value (e.g. `"NO_TAX"`) reaches the API and the whole request is rejected with:

> An unexpected error occurred while communicating with Xero

The `as` cast hides the mismatch from the type-checker, so it compiles cleanly.

This has been latent since the manual journal tools were introduced (#61). It normally stays hidden because callers omit `lineAmountTypes` and rely on Xero's `NoTax` default — it only surfaces when the field is set.

## Fix

Add a small `mapLineAmountType` helper that translates the tool input to the correct SDK enum, wire it into both tools, and drop the unsafe cast.

```ts
mapLineAmountType(args.lineAmountTypes),
```

## Testing

- New unit test `src/helpers/__tests__/map-line-amount-type.test.ts` covering each mapping and a regression guard that `NO_TAX` maps to `"NoTax"` (not `"NO_TAX"`).
- `npm run build`, `npm run lint`, `npm test` all pass.
- Verified end-to-end against a live Xero org: a `NO_TAX` manual journal that previously errored now posts successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)