### PR TITLE
Fix update-bank-transaction 400 when editing line items

### DIFF
--- a/src/handlers/update-xero-bank-transaction.handler.ts
+++ b/src/handlers/update-xero-bank-transaction.handler.ts
@@ -36,9 +36,17 @@ async function updateBankTransaction(
   reference?: string,
   date?: string
 ): Promise<BankTransaction | undefined> {
+  // Build a minimal payload with only editable fields plus the attributes Xero
+  // requires on update. Do NOT spread the fetched object: it carries read-only
+  // computed fields (subTotal/total/totalTax, updatedDateUTC, etc.) that go
+  // stale when lineItems change, causing a 400 "The document sub total does not
+  // equal the sub total of the lines". Omitting the totals lets Xero recompute.
   const bankTransaction: BankTransaction = {
-    ...existingBankTransaction,
     bankTransactionID: bankTransactionId,
+    bankAccount: existingBankTransaction.bankAccount,
+    lineAmountTypes: existingBankTransaction.lineAmountTypes,
+    status: existingBankTransaction.status,
+    currencyCode: existingBankTransaction.currencyCode,
     type: type ? BankTransaction.TypeEnum[type] : existingBankTransaction.type,
     contact: contactId ? { contactID: contactId } : existingBankTransaction.contact,
     lineItems: lineItems ? lineItems : existingBankTransaction.lineItems,


### PR DESCRIPTION
## Problem

Calling `update-bank-transaction` to edit an existing bank transaction's line items fails with:

> HTTP 400 — *"The document sub total does not equal the sub total of the lines"*

This happens even when only a line **description** changes and the monetary amount is identical.

## Root cause

`updateBankTransaction` in `src/handlers/update-xero-bank-transaction.handler.ts` builds the update payload by spreading the entire fetched transaction:

```ts
const bankTransaction: BankTransaction = {
  ...existingBankTransaction,   // carries read-only computed subTotal/total/totalTax
  ...
  lineItems: lineItems ? lineItems : existingBankTransaction.lineItems,
  ...
};
```

The spread carries Xero's **read-only computed** fields — `subTotal`, `total`, `totalTax`. When `lineItems` are replaced, Xero recomputes the line totals server-side, but the stale `subTotal`/`total` copied from the fetched object no longer reconcile, so the API rejects the update.

Per the [Xero BankTransactions API docs](https://developer.xero.com/documentation/api/accounting/banktransactions), `SubTotal`, `Total`, and `TotalTax` are each *"calculated by Xero and cannot be overridden."*

## Fix

Build a minimal payload containing only the editable fields plus the attributes Xero needs on update, and **omit the computed totals** so Xero recomputes them:

```ts
const bankTransaction: BankTransaction = {
  bankTransactionID: bankTransactionId,
  bankAccount: existingBankTransaction.bankAccount,
  lineAmountTypes: existingBankTransaction.lineAmountTypes,
  status: existingBankTransaction.status,
  currencyCode: existingBankTransaction.currencyCode,
  type: type ? BankTransaction.TypeEnum[type] : existingBankTransaction.type,
  contact: contactId ? { contactID: contactId } : existingBankTransaction.contact,
  lineItems: lineItems ? lineItems : existingBankTransaction.lineItems,
  reference: reference ? reference : existingBankTransaction.reference,
  date: date ? date : existingBankTransaction.date,
};
```

`lineAmountTypes` is preserved from the existing transaction rather than omitted: it defaults to *Exclusive* when absent, so dropping it could silently change the tax treatment (and therefore the recomputed totals) on inclusive-tax transactions.

## Verification

- `npm run build` — clean.
- `npm test` — 14/14 pass.
- Live-tested against a real AUTHORISED, tax-inclusive bank transaction: editing a line description now succeeds; the transaction's total, status, contact, and tax treatment are unchanged and the new description is persisted.