### PR TITLE
feat: add linked-transaction (billable expense) tools + surface Line Item ID

### DIFF
--- a/src/handlers/create-xero-linked-transaction.handler.ts
+++ b/src/handlers/create-xero-linked-transaction.handler.ts
@@ -1,0 +1,54 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { LinkedTransaction } from "xero-node";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+/**
+ * Create a linked transaction (billable expense) in Xero — stage 1: mark a source
+ * bill/spend line as billable to a customer. Optionally allocate it onto a sales
+ * invoice line in the same call by supplying the target fields.
+ */
+export async function createXeroLinkedTransaction(
+  sourceTransactionId: string,
+  sourceLineItemId: string,
+  contactId: string,
+  targetTransactionId?: string,
+  targetLineItemId?: string,
+): Promise<XeroClientResponse<LinkedTransaction>> {
+  try {
+    await xeroClient.authenticate();
+
+    const linkedTransaction: LinkedTransaction = {
+      sourceTransactionID: sourceTransactionId,
+      sourceLineItemID: sourceLineItemId,
+      contactID: contactId,
+      targetTransactionID: targetTransactionId,
+      targetLineItemID: targetLineItemId,
+    };
+
+    const response = await xeroClient.accountingApi.createLinkedTransaction(
+      xeroClient.tenantId,
+      linkedTransaction,
+      undefined, // idempotencyKey
+      getClientHeaders(),
+    );
+
+    const created = response.body.linkedTransactions?.[0];
+    if (!created) {
+      throw new Error("Linked transaction creation failed.");
+    }
+
+    return {
+      result: created,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/delete-xero-linked-transaction.handler.ts
+++ b/src/handlers/delete-xero-linked-transaction.handler.ts
@@ -1,0 +1,39 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+async function deleteLinkedTransaction(linkedTransactionId: string): Promise<boolean> {
+  await xeroClient.authenticate();
+
+  await xeroClient.accountingApi.deleteLinkedTransaction(
+    xeroClient.tenantId,
+    linkedTransactionId,
+    getClientHeaders(),
+  );
+
+  return true;
+}
+
+/**
+ * Delete a linked transaction (billable expense) in Xero
+ */
+export async function deleteXeroLinkedTransaction(
+  linkedTransactionId: string,
+): Promise<XeroClientResponse<boolean>> {
+  try {
+    await deleteLinkedTransaction(linkedTransactionId);
+
+    return {
+      result: true,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-invoices.handler.ts
+++ b/src/handlers/list-xero-invoices.handler.ts
@@ -8,6 +8,7 @@ async function getInvoices(
   invoiceNumbers: string[] | undefined,
   contactIds: string[] | undefined,
   page: number,
+  invoiceIds: string[] | undefined,
 ): Promise<Invoice[]> {
   await xeroClient.authenticate();
 
@@ -16,7 +17,7 @@ async function getInvoices(
     undefined, // ifModifiedSince
     undefined, // where
     "UpdatedDateUTC DESC", // order
-    undefined, // iDs
+    invoiceIds, // iDs
     invoiceNumbers, // invoiceNumbers
     contactIds, // contactIDs
     undefined, // statuses
@@ -39,9 +40,10 @@ export async function listXeroInvoices(
   page: number = 1,
   contactIds?: string[],
   invoiceNumbers?: string[],
+  invoiceIds?: string[],
 ): Promise<XeroClientResponse<Invoice[]>> {
   try {
-    const invoices = await getInvoices(invoiceNumbers, contactIds, page);
+    const invoices = await getInvoices(invoiceNumbers, contactIds, page, invoiceIds);
 
     return {
       result: invoices,

--- a/src/handlers/list-xero-linked-transactions.handler.ts
+++ b/src/handlers/list-xero-linked-transactions.handler.ts
@@ -1,0 +1,64 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { LinkedTransaction } from "xero-node";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+async function getLinkedTransactions(
+  page: number,
+  linkedTransactionId?: string,
+  sourceTransactionId?: string,
+  contactId?: string,
+  status?: string,
+  targetTransactionId?: string,
+): Promise<LinkedTransaction[]> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getLinkedTransactions(
+    xeroClient.tenantId,
+    page, // page
+    linkedTransactionId, // linkedTransactionID
+    sourceTransactionId, // sourceTransactionID
+    contactId, // contactID
+    status, // status
+    targetTransactionId, // targetTransactionID
+    getClientHeaders(),
+  );
+
+  return response.body.linkedTransactions ?? [];
+}
+
+/**
+ * List linked transactions (billable expenses) from Xero
+ */
+export async function listXeroLinkedTransactions(
+  page: number = 1,
+  linkedTransactionId?: string,
+  sourceTransactionId?: string,
+  contactId?: string,
+  status?: string,
+  targetTransactionId?: string,
+): Promise<XeroClientResponse<LinkedTransaction[]>> {
+  try {
+    const linkedTransactions = await getLinkedTransactions(
+      page,
+      linkedTransactionId,
+      sourceTransactionId,
+      contactId,
+      status,
+      targetTransactionId,
+    );
+
+    return {
+      result: linkedTransactions,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/update-xero-linked-transaction.handler.ts
+++ b/src/handlers/update-xero-linked-transaction.handler.ts
@@ -1,0 +1,59 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import { LinkedTransaction } from "xero-node";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+
+/**
+ * Update a linked transaction (billable expense) in Xero — stage 2: allocate it onto a
+ * sales-invoice line (set target) and/or change its source line, contact, or status.
+ */
+export async function updateXeroLinkedTransaction(
+  linkedTransactionId: string,
+  targetTransactionId?: string,
+  targetLineItemId?: string,
+  sourceLineItemId?: string,
+  contactId?: string,
+  status?: string,
+): Promise<XeroClientResponse<LinkedTransaction>> {
+  try {
+    await xeroClient.authenticate();
+
+    const linkedTransaction: LinkedTransaction = {
+      targetTransactionID: targetTransactionId,
+      targetLineItemID: targetLineItemId,
+      sourceLineItemID: sourceLineItemId,
+      contactID: contactId,
+      status: status
+        ? LinkedTransaction.StatusEnum[
+            status as keyof typeof LinkedTransaction.StatusEnum
+          ]
+        : undefined,
+    };
+
+    const response = await xeroClient.accountingApi.updateLinkedTransaction(
+      xeroClient.tenantId,
+      linkedTransactionId,
+      { linkedTransactions: [linkedTransaction] },
+      undefined, // idempotencyKey
+      getClientHeaders(),
+    );
+
+    const updated = response.body.linkedTransactions?.[0];
+    if (!updated) {
+      throw new Error("Linked transaction update failed.");
+    }
+
+    return {
+      result: updated,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/helpers/__tests__/format-line-item.test.ts
+++ b/src/helpers/__tests__/format-line-item.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { LineItem } from "xero-node";
+import { formatLineItem } from "../format-line-item.js";
+
+describe("formatLineItem", () => {
+  it("includes the line item ID so it can be used to link billable expenses", () => {
+    const lineItem = {
+      lineItemID: "li-123",
+      description: "Consulting services",
+      lineAmount: 120,
+    } as LineItem;
+
+    const result = formatLineItem(lineItem);
+
+    expect(result).toContain("Line Item ID: li-123");
+  });
+});

--- a/src/helpers/format-line-item.ts
+++ b/src/helpers/format-line-item.ts
@@ -3,6 +3,7 @@ import { LineItem } from "xero-node";
 export const formatLineItem = (lineItem: LineItem): string => {
   return [
     `Item ID: ${lineItem.item}`,
+    `Line Item ID: ${lineItem.lineItemID}`,
     `Item Code: ${lineItem.itemCode}`,
     `Description: ${lineItem.description}`,
     `Quantity: ${lineItem.quantity}`,

--- a/src/tools/create/create-linked-transaction.tool.ts
+++ b/src/tools/create/create-linked-transaction.tool.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import { createXeroLinkedTransaction } from "../../handlers/create-xero-linked-transaction.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const CreateLinkedTransactionTool = CreateXeroTool(
+  "create-linked-transaction",
+  `Create a linked transaction (billable expense) in Xero — stage 1 of recharging a cost to a
+  customer. Marks a single line on a source bill (ACCPAY) as billable to a customer so it can
+  later be allocated onto their sales invoice. Provide the source bill's transaction ID and the
+  specific line item ID to recharge (both from list-invoices — the line item ID is shown as
+  "Line Item ID" on each line), plus the customer's contact ID. Optionally also provide the
+  target sales invoice's transaction ID and line item ID to create and allocate in one step (only
+  if the sales invoice already exists; otherwise allocate later with update-linked-transaction).
+  Returns the created linked transaction with its ID.`,
+  {
+    sourceTransactionId: z
+      .string()
+      .describe("The ID of the source bill (ACCPAY invoice) the cost came from. Obtain from list-invoices."),
+    sourceLineItemId: z
+      .string()
+      .describe('The line item ID on the source bill to recharge. Shown as "Line Item ID" on the bill\'s line items in list-invoices.'),
+    contactId: z
+      .string()
+      .describe("The ID of the customer (contact) the expense is being recharged to. Obtain from list-contacts."),
+    targetTransactionId: z
+      .string()
+      .optional()
+      .describe("Optional: the ID of the sales invoice (ACCREC) to allocate this expense onto. Only if it already exists; otherwise allocate later with update-linked-transaction."),
+    targetLineItemId: z
+      .string()
+      .optional()
+      .describe('Optional: the line item ID on the target sales invoice to allocate onto. Shown as "Line Item ID" in list-invoices.'),
+  },
+  async ({
+    sourceTransactionId,
+    sourceLineItemId,
+    contactId,
+    targetTransactionId,
+    targetLineItemId,
+  }) => {
+    const response = await createXeroLinkedTransaction(
+      sourceTransactionId,
+      sourceLineItemId,
+      contactId,
+      targetTransactionId,
+      targetLineItemId,
+    );
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error creating linked transaction: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const lt = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Linked transaction created successfully:",
+            `Linked Transaction ID: ${lt?.linkedTransactionID}`,
+            `Status: ${lt?.status}`,
+            `Source Transaction ID: ${lt?.sourceTransactionID}`,
+            `Source Line Item ID: ${lt?.sourceLineItemID}`,
+            `Contact ID: ${lt?.contactID}`,
+            lt?.targetTransactionID ? `Target Transaction ID: ${lt.targetTransactionID}` : null,
+            lt?.targetLineItemID ? `Target Line Item ID: ${lt.targetLineItemID}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default CreateLinkedTransactionTool;

--- a/src/tools/create/index.ts
+++ b/src/tools/create/index.ts
@@ -3,6 +3,7 @@ import CreateContactTool from "./create-contact.tool.js";
 import CreateCreditNoteTool from "./create-credit-note.tool.js";
 import CreateInvoiceTool from "./create-invoice.tool.js";
 import CreateItemTool from "./create-item.tool.js";
+import CreateLinkedTransactionTool from "./create-linked-transaction.tool.js";
 import CreateManualJournalTool from "./create-manual-journal.tool.js";
 import CreatePaymentTool from "./create-payment.tool.js";
 import CreatePayrollTimesheetTool from "./create-payroll-timesheet.tool.js";
@@ -21,5 +22,6 @@ export const CreateTools = [
   CreateBankTransactionTool,
   CreatePayrollTimesheetTool,
   CreateTrackingCategoryTool,
-  CreateTrackingOptionsTool
+  CreateTrackingOptionsTool,
+  CreateLinkedTransactionTool
 ];

--- a/src/tools/delete/delete-linked-transaction.tool.ts
+++ b/src/tools/delete/delete-linked-transaction.tool.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { deleteXeroLinkedTransaction } from "../../handlers/delete-xero-linked-transaction.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const DeleteLinkedTransactionTool = CreateXeroTool(
+  "delete-linked-transaction",
+  `Delete a linked transaction (billable expense) in Xero by its ID. Use this to undo a
+  billable-expense link created in error. Obtain the ID from list-linked-transactions.`,
+  {
+    linkedTransactionId: z
+      .string()
+      .describe("The ID of the linked transaction to delete. Obtain from list-linked-transactions."),
+  },
+  async ({ linkedTransactionId }: { linkedTransactionId: string }) => {
+    const response = await deleteXeroLinkedTransaction(linkedTransactionId);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error deleting linked transaction: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Successfully deleted linked transaction with ID: ${linkedTransactionId}`,
+        },
+      ],
+    };
+  },
+);
+
+export default DeleteLinkedTransactionTool;

--- a/src/tools/delete/index.ts
+++ b/src/tools/delete/index.ts
@@ -1,5 +1,7 @@
 import DeletePayrollTimesheetTool from "./delete-payroll-timesheet.tool.js";
+import DeleteLinkedTransactionTool from "./delete-linked-transaction.tool.js";
 
 export const DeleteTools = [
-  DeletePayrollTimesheetTool
+  DeletePayrollTimesheetTool,
+  DeleteLinkedTransactionTool
 ];

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -7,6 +7,7 @@ import ListContactsTool from "./list-contacts.tool.js";
 import ListCreditNotesTool from "./list-credit-notes.tool.js";
 import ListInvoicesTool from "./list-invoices.tool.js";
 import ListItemsTool from "./list-items.tool.js";
+import ListLinkedTransactionsTool from "./list-linked-transactions.tool.js";
 import ListManualJournalsTool from "./list-manual-journals.tool.js";
 import ListOrganisationDetailsTool from "./list-organisation-details.tool.js";
 import ListPaymentsTool from "./list-payments.tool.js";
@@ -34,6 +35,7 @@ export const ListTools = [
   ListContactsTool,
   ListCreditNotesTool,
   ListInvoicesTool,
+  ListLinkedTransactionsTool,
   ListItemsTool,
   ListManualJournalsTool,
   ListQuotesTool,

--- a/src/tools/list/list-invoices.tool.ts
+++ b/src/tools/list/list-invoices.tool.ts
@@ -19,9 +19,20 @@ const ListInvoicesTool = CreateXeroTool(
       .array(z.string())
       .optional()
       .describe("If provided, invoice line items will also be returned"),
+    invoiceIds: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Filter by invoice IDs. When provided, invoice line items (including each line's Line Item ID) will also be returned",
+      ),
   },
-  async ({ page, contactIds, invoiceNumbers }) => {
-    const response = await listXeroInvoices(page, contactIds, invoiceNumbers);
+  async ({ page, contactIds, invoiceNumbers, invoiceIds }) => {
+    const response = await listXeroInvoices(
+      page,
+      contactIds,
+      invoiceNumbers,
+      invoiceIds,
+    );
     if (response.error !== null) {
       return {
         content: [
@@ -34,7 +45,8 @@ const ListInvoicesTool = CreateXeroTool(
     }
 
     const invoices = response.result;
-    const returnLineItems = (invoiceNumbers?.length ?? 0) > 0;
+    const returnLineItems =
+      (invoiceNumbers?.length ?? 0) > 0 || (invoiceIds?.length ?? 0) > 0;
 
     return {
       content: [

--- a/src/tools/list/list-linked-transactions.tool.ts
+++ b/src/tools/list/list-linked-transactions.tool.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+import { listXeroLinkedTransactions } from "../../handlers/list-xero-linked-transactions.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const ListLinkedTransactionsTool = CreateXeroTool(
+  "list-linked-transactions",
+  `List linked transactions (billable expenses) in Xero. A billable expense links a cost on a
+  source bill (ACCPAY) or spend-money transaction to a customer so it can be recharged onto
+  their sales invoice (ACCREC). Filter by any combination of: a single linkedTransactionId
+  (exact fetch), sourceTransactionId (all links from one bill), contactId (the customer the
+  expense is assigned to), status (APPROVED/DRAFT/ONDRAFT/BILLED/VOIDED), or targetTransactionId
+  (all links allocated onto one sales invoice). To find expenses that are ready to recharge to a
+  customer, filter by contactId plus status "APPROVED". Ask the user if they want the next page
+  after a full page is returned; if so, call again with the next page number.`,
+  {
+    page: z.number(),
+    linkedTransactionId: z
+      .string()
+      .optional()
+      .describe("Fetch a single linked transaction by its ID."),
+    sourceTransactionId: z
+      .string()
+      .optional()
+      .describe("Filter to links created from this source bill/spend transaction ID."),
+    contactId: z
+      .string()
+      .optional()
+      .describe("Filter to links assigned to this customer (contact) ID."),
+    status: z
+      .string()
+      .optional()
+      .describe("Filter by status: APPROVED, DRAFT, ONDRAFT, BILLED, or VOIDED."),
+    targetTransactionId: z
+      .string()
+      .optional()
+      .describe("Filter to links allocated onto this sales invoice (target) ID."),
+  },
+  async ({
+    page,
+    linkedTransactionId,
+    sourceTransactionId,
+    contactId,
+    status,
+    targetTransactionId,
+  }) => {
+    const response = await listXeroLinkedTransactions(
+      page,
+      linkedTransactionId,
+      sourceTransactionId,
+      contactId,
+      status,
+      targetTransactionId,
+    );
+    if (response.error !== null) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing linked transactions: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const linkedTransactions = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${linkedTransactions?.length || 0} linked transactions:`,
+        },
+        ...(linkedTransactions?.map((lt) => ({
+          type: "text" as const,
+          text: [
+            `Linked Transaction ID: ${lt.linkedTransactionID}`,
+            `Status: ${lt.status || "Unknown"}`,
+            `Type: ${lt.type || "Unknown"}`,
+            lt.sourceTransactionID ? `Source Transaction ID: ${lt.sourceTransactionID}` : null,
+            lt.sourceLineItemID ? `Source Line Item ID: ${lt.sourceLineItemID}` : null,
+            lt.sourceTransactionTypeCode ? `Source Type: ${lt.sourceTransactionTypeCode}` : null,
+            lt.contactID ? `Contact ID: ${lt.contactID}` : null,
+            lt.targetTransactionID ? `Target Transaction ID: ${lt.targetTransactionID}` : null,
+            lt.targetLineItemID ? `Target Line Item ID: ${lt.targetLineItemID}` : null,
+            lt.updatedDateUTC ? `Last Updated: ${lt.updatedDateUTC}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListLinkedTransactionsTool;

--- a/src/tools/update/index.ts
+++ b/src/tools/update/index.ts
@@ -5,6 +5,7 @@ import UpdateContactTool from "./update-contact.tool.js";
 import UpdateCreditNoteTool from "./update-credit-note.tool.js";
 import UpdateInvoiceTool from "./update-invoice.tool.js";
 import UpdateItemTool from "./update-item.tool.js";
+import UpdateLinkedTransactionTool from "./update-linked-transaction.tool.js";
 import AddTimesheetLineTool from "./update-payroll-timesheet-add-line.tool.js";
 import UpdatePayrollTimesheetLineTool
   from "./update-payroll-timesheet-update-line.tool.js";
@@ -26,5 +27,6 @@ export const UpdateTools = [
   UpdatePayrollTimesheetLineTool,
   RevertPayrollTimesheetTool,
   UpdateTrackingCategoryTool,
-  UpdateTrackingOptionsTool
+  UpdateTrackingOptionsTool,
+  UpdateLinkedTransactionTool
 ];

--- a/src/tools/update/update-linked-transaction.tool.ts
+++ b/src/tools/update/update-linked-transaction.tool.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+import { updateXeroLinkedTransaction } from "../../handlers/update-xero-linked-transaction.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const UpdateLinkedTransactionTool = CreateXeroTool(
+  "update-linked-transaction",
+  `Update a linked transaction (billable expense) in Xero — stage 2 of recharging a cost to a
+  customer. Use this to allocate an existing billable expense onto a customer's sales invoice by
+  setting the target sales invoice's transaction ID and line item ID (both from list-invoices —
+  the line item ID is shown as "Line Item ID"). You can also change the source line item,
+  reassign the customer (contact), or change the status. Provide the linked transaction ID (from
+  list-linked-transactions) plus only the fields you want to change. Returns the updated linked
+  transaction.`,
+  {
+    linkedTransactionId: z
+      .string()
+      .describe("The ID of the linked transaction to update. Obtain from list-linked-transactions."),
+    targetTransactionId: z
+      .string()
+      .optional()
+      .describe("The ID of the sales invoice (ACCREC) to allocate this expense onto. Obtain from list-invoices."),
+    targetLineItemId: z
+      .string()
+      .optional()
+      .describe('The line item ID on the target sales invoice to allocate onto. Shown as "Line Item ID" in list-invoices.'),
+    sourceLineItemId: z
+      .string()
+      .optional()
+      .describe("Change the source bill line item this expense came from."),
+    contactId: z
+      .string()
+      .optional()
+      .describe("Reassign the customer (contact) the expense is recharged to. Obtain from list-contacts."),
+    status: z
+      .enum(["APPROVED", "DRAFT", "ONDRAFT", "BILLED", "VOIDED"])
+      .optional()
+      .describe("Change the status of the linked transaction."),
+  },
+  async ({
+    linkedTransactionId,
+    targetTransactionId,
+    targetLineItemId,
+    sourceLineItemId,
+    contactId,
+    status,
+  }) => {
+    const response = await updateXeroLinkedTransaction(
+      linkedTransactionId,
+      targetTransactionId,
+      targetLineItemId,
+      sourceLineItemId,
+      contactId,
+      status,
+    );
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error updating linked transaction: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const lt = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Linked transaction updated successfully:",
+            `Linked Transaction ID: ${lt?.linkedTransactionID}`,
+            `Status: ${lt?.status}`,
+            `Source Transaction ID: ${lt?.sourceTransactionID}`,
+            `Source Line Item ID: ${lt?.sourceLineItemID}`,
+            `Contact ID: ${lt?.contactID}`,
+            lt?.targetTransactionID ? `Target Transaction ID: ${lt.targetTransactionID}` : null,
+            lt?.targetLineItemID ? `Target Line Item ID: ${lt.targetLineItemID}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default UpdateLinkedTransactionTool;


### PR DESCRIPTION
Adds four thin-wrapper tools mapping 1:1 to the SDK: list-linked-transactions, create-linked-transaction, update-linked-transaction, and delete-linked-transaction. These cover the billable-expense flow — marking a cost on a source bill (ACCPAY) line as billable to a customer (stage 1) and allocating it onto that customer's sales invoice line (stage 2). Also surfaces each line's `Line Item ID` in formatLineItem, which the flow depends on to obtain source/target line IDs (with a Vitest test, matching the repo's helper-test convention). Mirrors the existing list-credit-notes / create-invoice / update-invoice / delete-payroll-timesheet patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)