### PR TITLE
feat: add delete-credit-note-allocation tool (+ show allocations in list-credit-notes)

### DIFF
--- a/src/handlers/delete-xero-credit-note-allocation.handler.ts
+++ b/src/handlers/delete-xero-credit-note-allocation.handler.ts
@@ -1,0 +1,49 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { Allocation } from "xero-node";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function deleteCreditNoteAllocation(
+  creditNoteId: string,
+  allocationId: string,
+): Promise<Allocation> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.deleteCreditNoteAllocations(
+    xeroClient.tenantId,
+    creditNoteId, // creditNoteID
+    allocationId, // allocationID
+    getClientHeaders(), // options
+  );
+
+  return response.body;
+}
+
+/**
+ * Delete (remove) an allocation from a credit note in Xero,
+ * returning the allocated amount to the credit note's remaining credit.
+ */
+export async function deleteXeroCreditNoteAllocation(
+  creditNoteId: string,
+  allocationId: string,
+): Promise<XeroClientResponse<Allocation>> {
+  try {
+    const deletedAllocation = await deleteCreditNoteAllocation(
+      creditNoteId,
+      allocationId,
+    );
+
+    return {
+      result: deletedAllocation,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/tools/delete/delete-credit-note-allocation.tool.ts
+++ b/src/tools/delete/delete-credit-note-allocation.tool.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { deleteXeroCreditNoteAllocation } from "../../handlers/delete-xero-credit-note-allocation.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const DeleteCreditNoteAllocationTool = CreateXeroTool(
+  "delete-credit-note-allocation",
+  `Delete (remove) an allocation from a credit note in Xero. Use this to undo applying
+  credit to an invoice, for example before editing or re-allocating the credit note.
+  The allocated amount is returned to the credit note's remaining credit and the invoice's
+  amount due increases accordingly. Obtain the allocation ID from list-credit-notes.`,
+  {
+    creditNoteId: z
+      .string()
+      .describe("The ID of the credit note the allocation belongs to."),
+    allocationId: z
+      .string()
+      .describe(
+        "The ID of the allocation to delete. Obtain from list-credit-notes.",
+      ),
+  },
+  async ({
+    creditNoteId,
+    allocationId,
+  }: {
+    creditNoteId: string;
+    allocationId: string;
+  }) => {
+    const response = await deleteXeroCreditNoteAllocation(
+      creditNoteId,
+      allocationId,
+    );
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error deleting credit note allocation: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const allocation = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Credit note allocation deleted successfully.",
+            allocation?.amount !== undefined
+              ? `Amount returned to credit note: ${allocation.amount}`
+              : null,
+            allocation?.invoice?.invoiceID
+              ? `Was allocated to invoice: ${allocation.invoice.invoiceID}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default DeleteCreditNoteAllocationTool;

--- a/src/tools/delete/index.ts
+++ b/src/tools/delete/index.ts
@@ -1,5 +1,7 @@
+import DeleteCreditNoteAllocationTool from "./delete-credit-note-allocation.tool.js";
 import DeletePayrollTimesheetTool from "./delete-payroll-timesheet.tool.js";
 
 export const DeleteTools = [
+  DeleteCreditNoteAllocationTool,
   DeletePayrollTimesheetTool
 ];

--- a/src/tools/list/list-credit-notes.tool.ts
+++ b/src/tools/list/list-credit-notes.tool.ts
@@ -9,8 +9,10 @@ const ListCreditNotesTool = CreateXeroTool(
   or to see all credit notes before running. 
   Ask the user if they want the next page of credit notes after running this tool 
   if 10 credit notes are returned. 
-  If they want the next page, call this tool again with the next page number 
-  and the contact if one was provided in the previous call.`,
+  If they want the next page, call this tool again with the next page number
+  and the contact if one was provided in the previous call.
+  Each credit note includes its allocations (credit applied to invoices); the allocation IDs
+  can be used with delete-credit-note-allocation to remove an allocation.`,
   {
     page: z.number(),
     contactId: z.string().optional(),
@@ -54,6 +56,27 @@ const ListCreditNotesTool = CreateXeroTool(
             creditNote.subTotal ? `Sub Total: ${creditNote.subTotal}` : null,
             creditNote.totalTax ? `Total Tax: ${creditNote.totalTax}` : null,
             `Total: ${creditNote.total || 0}`,
+            creditNote.remainingCredit !== undefined
+              ? `Remaining Credit: ${creditNote.remainingCredit}`
+              : null,
+            ...(creditNote.allocations?.map((allocation, index) =>
+              [
+                `Allocation ${index + 1}:`,
+                allocation.allocationID
+                  ? `  Allocation ID: ${allocation.allocationID}`
+                  : null,
+                `  Amount: ${allocation.amount}`,
+                allocation.date ? `  Date: ${allocation.date}` : null,
+                allocation.invoice?.invoiceID
+                  ? `  Invoice ID: ${allocation.invoice.invoiceID}`
+                  : null,
+                allocation.invoice?.invoiceNumber
+                  ? `  Invoice Number: ${allocation.invoice.invoiceNumber}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join("\n"),
+            ) ?? []),
             creditNote.currencyCode
               ? `Currency: ${creditNote.currencyCode}`
               : null,


### PR DESCRIPTION
## What

Adds a `delete-credit-note-allocation` tool wrapping `AccountingApi.deleteCreditNoteAllocations`, and extends `list-credit-notes` output with each credit note's allocations (allocation ID, amount, date, target invoice) and remaining credit so allocation IDs are discoverable.

## Why

`create-credit-note-allocation` can apply credit to an invoice, but there is currently no way to undo an allocation made in error — or to free up an allocated credit note so it can be corrected and re-applied. The common bookkeeping flow "de-allocate → fix → re-allocate" is impossible via the MCP today. Notably, once a credit note is fully allocated Xero flips its status to PAID, so nothing about it can be changed until the allocation is removed.

`list-credit-notes` previously didn't show allocations at all, so even with a delete tool there was no way to obtain an allocation ID; this PR surfaces them in the existing list output.

## Changes

- `src/handlers/delete-xero-credit-note-allocation.handler.ts` — thin wrapper around `deleteCreditNoteAllocations(tenantId, creditNoteID, allocationID)`
- `src/tools/delete/delete-credit-note-allocation.tool.ts` — MCP tool (`creditNoteId`, `allocationId`)
- `src/tools/delete/index.ts` — register the tool
- `src/tools/list/list-credit-notes.tool.ts` — include remaining credit + allocations (with IDs) per credit note

## Testing

- `npm run build`, `npm run lint`, `npm test` all pass
- Live-verified against a real Xero tenant: created a throwaway credit note + invoice, allocated the credit, confirmed the allocation (with its ID) appears in `list-credit-notes`, deleted the allocation via the new tool, and confirmed the allocation disappeared and the credit note's remaining credit returned to the full amount (status PAID → AUTHORISED). All fixtures voided/archived afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)