### PR TITLE
feat: allow date/reference updates on authorised credit notes

### DIFF
--- a/src/handlers/update-xero-credit-note.handler.ts
+++ b/src/handlers/update-xero-credit-note.handler.ts
@@ -69,12 +69,23 @@ export async function updateXeroCreditNote(
 
     const creditNoteStatus = existingCreditNote?.status;
 
-    // Only allow updates to DRAFT credit notes
-    if (creditNoteStatus !== CreditNote.StatusEnum.DRAFT) {
+    // DRAFT credit notes can be fully updated. AUTHORISED credit notes only
+    // accept changes to the date and reference; everything else is rejected.
+    if (creditNoteStatus === CreditNote.StatusEnum.AUTHORISED) {
+      if (lineItems || contactId) {
+        return {
+          result: null,
+          isError: true,
+          error:
+            "Only the date and reference of an authorised credit note can be updated. " +
+            "Line items and contact cannot be changed.",
+        };
+      }
+    } else if (creditNoteStatus !== CreditNote.StatusEnum.DRAFT) {
       return {
         result: null,
         isError: true,
-        error: `Cannot update credit note because it is not a draft. Current status: ${creditNoteStatus}`,
+        error: `Cannot update credit note because its status is ${creditNoteStatus}. Only draft credit notes can be fully updated; authorised credit notes can have their date and reference updated.`,
       };
     }
 

--- a/src/tools/update/update-credit-note.tool.ts
+++ b/src/tools/update/update-credit-note.tool.ts
@@ -13,7 +13,9 @@ const lineItemSchema = z.object({
 
 const UpdateCreditNoteTool = CreateXeroTool(
   "update-credit-note",
-  "Update a credit note in Xero. Only works on draft credit notes.\
+  "Update a credit note in Xero. Draft credit notes can be fully updated.\
+  Authorised (approved) credit notes can only have their date and reference updated;\
+  to change anything else, the credit note must be a draft.\
   All line items must be provided. Any line items not provided will be removed. Including existing line items.\
   Do not modify line items that have not been specified by the user.\
  When a credit note is updated, a deep link to the credit note in Xero is returned.\


### PR DESCRIPTION
## What

Relaxes the DRAFT-only guard on `update-credit-note` so that **AUTHORISED** credit notes can have their **date and reference** updated. Line items and contact remain locked once a credit note is approved, and PAID/VOIDED credit notes are still rejected.

## Why

Xero's API (and UI) permit limited edits to an approved credit note — most commonly correcting its date or reference. The MCP currently rejects any update to a non-draft credit note, forcing users into the Xero UI for a simple date fix. This pairs with #194: a fully allocated credit note reports status PAID, so the workflow for correcting it is de-allocate (PAID → AUTHORISED) → fix the date via this tool → re-allocate.

## Changes

- `src/handlers/update-xero-credit-note.handler.ts` — AUTHORISED credit notes accept date/reference updates; supplying `lineItems` or `contactId` for an authorised credit note returns a clear error; other non-draft statuses are rejected as before (with an updated message)
- `src/tools/update/update-credit-note.tool.ts` — tool description updated to match

## Testing

- `npm run build`, `npm run lint`, `npm test` all pass
- Live-verified against a real Xero tenant: re-dated an AUTHORISED (unallocated) credit note successfully; confirmed the handler rejects a line-item update on an AUTHORISED credit note; confirmed a PAID (fully allocated) credit note is still rejected with the new error message. Throwaway fixtures voided/archived afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)