### PR TITLE
feat(tools): add optional currencyRate param to multicurrency tools

### DIFF
--- a/src/handlers/create-xero-credit-note.handler.ts
+++ b/src/handlers/create-xero-credit-note.handler.ts
@@ -16,6 +16,7 @@ async function createCreditNote(
   contactId: string,
   lineItems: CreditNoteLineItem[],
   reference: string | undefined,
+  currencyRate: number | undefined,
 ): Promise<CreditNote | undefined> {
   await xeroClient.authenticate();
 
@@ -28,6 +29,7 @@ async function createCreditNote(
     date: new Date().toISOString().split("T")[0], // Today's date
     reference: reference,
     status: CreditNote.StatusEnum.DRAFT,
+    currencyRate: currencyRate,
   };
 
   const response = await xeroClient.accountingApi.createCreditNotes(
@@ -51,12 +53,14 @@ export async function createXeroCreditNote(
   contactId: string,
   lineItems: CreditNoteLineItem[],
   reference?: string,
+  currencyRate?: number,
 ): Promise<XeroClientResponse<CreditNote>> {
   try {
     const createdCreditNote = await createCreditNote(
       contactId,
       lineItems,
       reference,
+      currencyRate,
     );
 
     if (!createdCreditNote) {

--- a/src/handlers/create-xero-invoice.handler.ts
+++ b/src/handlers/create-xero-invoice.handler.ts
@@ -20,6 +20,7 @@ async function createInvoice(
   type: Invoice.TypeEnum,
   reference: string | undefined,
   date: string | undefined,
+  currencyRate: number | undefined,
 ): Promise<Invoice | undefined> {
   await xeroClient.authenticate();
 
@@ -37,6 +38,7 @@ async function createInvoice(
       ? { invoiceNumber: reference }
       : { reference: reference }),
     status: Invoice.StatusEnum.DRAFT,
+    currencyRate: currencyRate,
   };
 
   const response = await xeroClient.accountingApi.createInvoices(
@@ -62,6 +64,7 @@ export async function createXeroInvoice(
   type: Invoice.TypeEnum = Invoice.TypeEnum.ACCREC,
   reference?: string,
   date?: string,
+  currencyRate?: number,
 ): Promise<XeroClientResponse<Invoice>> {
   try {
     const createdInvoice = await createInvoice(
@@ -70,6 +73,7 @@ export async function createXeroInvoice(
       type,
       reference,
       date,
+      currencyRate,
     );
 
     if (!createdInvoice) {

--- a/src/handlers/create-xero-payment.handler.ts
+++ b/src/handlers/create-xero-payment.handler.ts
@@ -10,6 +10,7 @@ type PaymentProps = {
   amount: number;
   date?: string;
   reference?: string;
+  currencyRate?: number;
 };
 
 async function createPayment({
@@ -18,6 +19,7 @@ async function createPayment({
   amount,
   date,
   reference,
+  currencyRate,
 }: PaymentProps): Promise<Payment | undefined> {
   await xeroClient.authenticate();
 
@@ -31,6 +33,7 @@ async function createPayment({
     amount: amount,
     date: date || new Date().toISOString().split("T")[0], // Today's date if not specified
     reference: reference,
+    currencyRate: currencyRate,
   };
 
   const response = await xeroClient.accountingApi.createPayment(
@@ -52,6 +55,7 @@ export async function createXeroPayment({
   amount,
   date,
   reference,
+  currencyRate,
 }: PaymentProps): Promise<XeroClientResponse<Payment>> {
   try {
     const createdPayment = await createPayment({
@@ -60,6 +64,7 @@ export async function createXeroPayment({
       amount,
       date,
       reference,
+      currencyRate,
     });
 
     if (!createdPayment) {

--- a/src/handlers/create-xero-quote.handler.ts
+++ b/src/handlers/create-xero-quote.handler.ts
@@ -20,6 +20,7 @@ async function createQuote(
   lineItems: QuoteLineItem[],
   title: string | undefined,
   summary: string | undefined,
+  currencyRate: number | undefined,
 ): Promise<Quote | undefined> {
   await xeroClient.authenticate();
 
@@ -38,6 +39,7 @@ async function createQuote(
     status: QuoteStatusCodes.DRAFT,
     title: title,
     summary: summary,
+    currencyRate: currencyRate,
   };
 
   const response = await xeroClient.accountingApi.createQuotes(
@@ -64,6 +66,7 @@ export async function createXeroQuote(
   terms?: string,
   title?: string,
   summary?: string,
+  currencyRate?: number,
 ): Promise<XeroClientResponse<Quote>> {
   try {
     const createdQuote = await createQuote(
@@ -74,6 +77,7 @@ export async function createXeroQuote(
       lineItems,
       title,
       summary,
+      currencyRate,
     );
 
     if (!createdQuote) {

--- a/src/handlers/update-xero-credit-note.handler.ts
+++ b/src/handlers/update-xero-credit-note.handler.ts
@@ -32,12 +32,14 @@ async function updateCreditNote(
   reference?: string,
   contactId?: string,
   date?: string,
+  currencyRate?: number,
 ): Promise<CreditNote | null> {
   const creditNote: CreditNote = {
     lineItems: lineItems,
     reference: reference,
     date: date,
     contact: contactId ? { contactID: contactId } : undefined,
+    currencyRate: currencyRate,
   };
 
   const response = await xeroClient.accountingApi.updateCreditNote(
@@ -63,6 +65,7 @@ export async function updateXeroCreditNote(
   reference?: string,
   contactId?: string,
   date?: string,
+  currencyRate?: number,
 ): Promise<XeroClientResponse<CreditNote>> {
   try {
     const existingCreditNote = await getCreditNote(creditNoteId);
@@ -84,6 +87,7 @@ export async function updateXeroCreditNote(
       reference,
       contactId,
       date,
+      currencyRate,
     );
 
     if (!updatedCreditNote) {

--- a/src/handlers/update-xero-invoice.handler.ts
+++ b/src/handlers/update-xero-invoice.handler.ts
@@ -35,6 +35,7 @@ async function updateInvoice(
   dueDate?: string,
   date?: string,
   contactId?: string,
+  currencyRate?: number,
 ): Promise<Invoice | undefined> {
   const invoice: Invoice = {
     lineItems: lineItems,
@@ -42,6 +43,7 @@ async function updateInvoice(
     dueDate: dueDate,
     date: date,
     contact: contactId ? { contactID: contactId } : undefined,
+    currencyRate: currencyRate,
   };
 
   const response = await xeroClient.accountingApi.updateInvoice(
@@ -68,6 +70,7 @@ export async function updateXeroInvoice(
   dueDate?: string,
   date?: string,
   contactId?: string,
+  currencyRate?: number,
 ): Promise<XeroClientResponse<Invoice>> {
   try {
     const existingInvoice = await getInvoice(invoiceId);
@@ -90,6 +93,7 @@ export async function updateXeroInvoice(
       dueDate,
       date,
       contactId,
+      currencyRate,
     );
 
     if (!updatedInvoice) {

--- a/src/handlers/update-xero-quote.handler.ts
+++ b/src/handlers/update-xero-quote.handler.ts
@@ -36,7 +36,8 @@ async function updateQuote(
   contactId?: string,
   date?: string,
   expiryDate?: string,
-  existingQuote?: Quote
+  existingQuote?: Quote,
+  currencyRate?: number,
 ): Promise<Quote | undefined> {
   // Create quote object with only the fields that are being updated
   const quote: Quote = {
@@ -47,6 +48,7 @@ async function updateQuote(
     summary: summary,
     quoteNumber: quoteNumber,
     expiryDate: expiryDate,
+    currencyRate: currencyRate,
   };
   
   // Only add contact if contactId is provided, otherwise use existing
@@ -90,6 +92,7 @@ export async function updateXeroQuote(
   contactId?: string,
   date?: string,
   expiryDate?: string,
+  currencyRate?: number,
 ): Promise<XeroClientResponse<Quote>> {
   try {
     const existingQuote = await getQuote(quoteId);
@@ -116,7 +119,8 @@ export async function updateXeroQuote(
       contactId,
       date,
       expiryDate,
-      existingQuote
+      existingQuote,
+      currencyRate,
     );
 
     if (!updatedQuote) {

--- a/src/tools/create/create-credit-note.tool.ts
+++ b/src/tools/create/create-credit-note.tool.ts
@@ -21,9 +21,10 @@ const CreateCreditNoteTool = CreateXeroTool(
     contactId: z.string(),
     lineItems: z.array(lineItemSchema),
     reference: z.string().optional(),
+    currencyRate: z.number().positive().optional().describe("Optional exchange rate to base currency (e.g. 0.75). Only required for non-base currency credit notes. Defaults to XE.com day rate if omitted."),
   },
-  async ({ contactId, lineItems, reference }) => {
-    const result = await createXeroCreditNote(contactId, lineItems, reference);
+  async ({ contactId, lineItems, reference, currencyRate }) => {
+    const result = await createXeroCreditNote(contactId, lineItems, reference, currencyRate);
     if (result.isError) {
       return {
         content: [

--- a/src/tools/create/create-invoice.tool.ts
+++ b/src/tools/create/create-invoice.tool.ts
@@ -41,10 +41,11 @@ const CreateInvoiceTool = CreateXeroTool(
       If the type is not specified, the default is ACCREC."),
     reference: z.string().describe("A reference number for the invoice.").optional(),
     date: z.string().describe("The date the invoice was created (YYYY-MM-DD format).").optional(),
+    currencyRate: z.number().positive().optional().describe("Optional exchange rate to base currency (e.g. 0.75). Only required for non-base currency invoices. Defaults to XE.com day rate if omitted."),
   },
-  async ({ contactId, lineItems, type, reference, date }) => {
+  async ({ contactId, lineItems, type, reference, date, currencyRate }) => {
     const xeroInvoiceType = type === "ACCREC" ? Invoice.TypeEnum.ACCREC : Invoice.TypeEnum.ACCPAY;
-    const result = await createXeroInvoice(contactId, lineItems, xeroInvoiceType, reference, date);
+    const result = await createXeroInvoice(contactId, lineItems, xeroInvoiceType, reference, date, currencyRate);
     if (result.isError) {
       return {
         content: [

--- a/src/tools/create/create-payment.tool.ts
+++ b/src/tools/create/create-payment.tool.ts
@@ -31,14 +31,20 @@ const CreatePaymentTool = CreateXeroTool(
       .string()
       .optional()
       .describe("Optional payment reference/description"),
+    currencyRate: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Optional exchange rate to base currency (e.g. 0.75). Only required for non-base currency invoices. Defaults to XE.com day rate if omitted."),
   },
-  async ({ invoiceId, accountId, amount, date, reference }) => {
+  async ({ invoiceId, accountId, amount, date, reference, currencyRate }) => {
     const result = await createXeroPayment({
       invoiceId,
       accountId,
       amount,
       date,
       reference,
+      currencyRate,
     });
     if (result.isError) {
       return {

--- a/src/tools/create/create-quote.tool.ts
+++ b/src/tools/create/create-quote.tool.ts
@@ -25,6 +25,7 @@ const CreateQuoteTool = CreateXeroTool(
     terms: z.string().optional(),
     title: z.string().optional(),
     summary: z.string().optional(),
+    currencyRate: z.number().positive().optional().describe("Optional exchange rate to base currency (e.g. 0.75). Only required for non-base currency quotes. Defaults to XE.com day rate if omitted."),
   },
   async ({
     contactId,
@@ -34,6 +35,7 @@ const CreateQuoteTool = CreateXeroTool(
     terms,
     title,
     summary,
+    currencyRate,
   }) => {
     const result = await createXeroQuote(
       contactId,
@@ -43,6 +45,7 @@ const CreateQuoteTool = CreateXeroTool(
       terms,
       title,
       summary,
+      currencyRate,
     );
     if (result.isError) {
       return {

--- a/src/tools/update/update-credit-note.tool.ts
+++ b/src/tools/update/update-credit-note.tool.ts
@@ -28,6 +28,7 @@ const UpdateCreditNoteTool = CreateXeroTool(
     reference: z.string().optional(),
     date: z.string().optional(),
     contactId: z.string().optional(),
+    currencyRate: z.number().positive().optional().describe("Optional exchange rate to base currency (e.g. 0.75). Only required for non-base currency credit notes. Defaults to XE.com day rate if omitted."),
   },
   async (
     {
@@ -36,6 +37,7 @@ const UpdateCreditNoteTool = CreateXeroTool(
       reference,
       date,
       contactId,
+      currencyRate,
     }: {
       creditNoteId: string;
       lineItems?: Array<{
@@ -48,6 +50,7 @@ const UpdateCreditNoteTool = CreateXeroTool(
       reference?: string;
       date?: string;
       contactId?: string;
+      currencyRate?: number;
     },
   ) => {
     const result = await updateXeroCreditNote(
@@ -56,6 +59,7 @@ const UpdateCreditNoteTool = CreateXeroTool(
       reference,
       contactId,
       date,
+      currencyRate,
     );
     if (result.isError) {
       return {

--- a/src/tools/update/update-invoice.tool.ts
+++ b/src/tools/update/update-invoice.tool.ts
@@ -44,6 +44,7 @@ const UpdateInvoiceTool = CreateXeroTool(
     date: z.string().optional().describe("The date of the invoice."),
     contactId: z.string().optional().describe("The ID of the contact to update the invoice for. \
       Can be obtained from the list-contacts tool."),
+    currencyRate: z.number().positive().optional().describe("Optional exchange rate to base currency (e.g. 0.75). Only required for non-base currency invoices. Defaults to XE.com day rate if omitted."),
   },
   async (
     {
@@ -53,6 +54,7 @@ const UpdateInvoiceTool = CreateXeroTool(
       dueDate,
       date,
       contactId,
+      currencyRate,
     }: {
       invoiceId: string;
       lineItems?: Array<{
@@ -66,6 +68,7 @@ const UpdateInvoiceTool = CreateXeroTool(
       dueDate?: string;
       date?: string;
       contactId?: string;
+      currencyRate?: number;
     },
     //_extra: { signal: AbortSignal },
   ) => {
@@ -76,6 +79,7 @@ const UpdateInvoiceTool = CreateXeroTool(
       dueDate,
       date,
       contactId,
+      currencyRate,
     );
     if (result.isError) {
       return {

--- a/src/tools/update/update-quote.tool.ts
+++ b/src/tools/update/update-quote.tool.ts
@@ -33,6 +33,7 @@ const UpdateQuoteTool = CreateXeroTool(
     contactId: z.string().optional(),
     date: z.string().optional(),
     expiryDate: z.string().optional(),
+    currencyRate: z.number().positive().optional().describe("Optional exchange rate to base currency (e.g. 0.75). Only required for non-base currency quotes. Defaults to XE.com day rate if omitted."),
   },
   async (
     {
@@ -46,6 +47,7 @@ const UpdateQuoteTool = CreateXeroTool(
       contactId,
       date,
       expiryDate,
+      currencyRate,
     }
   ) => {
     const result = await updateXeroQuote(
@@ -59,6 +61,7 @@ const UpdateQuoteTool = CreateXeroTool(
       contactId,
       date,
       expiryDate,
+      currencyRate,
     );
     if (result.isError) {
       return {


### PR DESCRIPTION
## Summary

- Exposes `currencyRate` as an optional parameter on all create/update tools that support multicurrency transactions
- Previously missing, causing failures when working with non-base currency invoices, bills, payments, credit notes, and quotes
- The field already exists on all `xero-node` SDK types but was not wired through to the tool layer

## Affected tools

- `create-invoice` / `update-invoice`
- `create-payment`
- `create-credit-note` / `update-credit-note`
- `create-quote` / `update-quote`

## Behaviour

- If `currencyRate` is omitted, Xero defaults to the XE.com day rate (existing behaviour unchanged)
- If provided, the supplied rate is used for the transaction

## Test plan

- [ ] Create a foreign currency invoice with `currencyRate` — confirm Xero accepts it
- [ ] Create a payment against a foreign currency invoice with `currencyRate` — confirm no error
- [ ] Create/update without `currencyRate` — confirm existing behaviour unchanged