### PR TITLE
Fix list-invoices rendering line-item tracking and item as [object Object]

### DIFF
--- a/src/helpers/__tests__/format-line-item.test.ts
+++ b/src/helpers/__tests__/format-line-item.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { LineItem } from "xero-node";
+import { formatLineItem } from "../format-line-item.js";
+
+describe("formatLineItem", () => {
+  it("renders tracking as name=option, comma-separated", () => {
+    const lineItem = {
+      description: "Consulting",
+      quantity: 1,
+      unitAmount: 10,
+      accountCode: "200",
+      taxType: "OUTPUT",
+      lineAmount: 10,
+      tracking: [
+        { name: "Region", option: "West" },
+        { name: "Team", option: "Alpha" },
+      ],
+    } as LineItem;
+
+    expect(formatLineItem(lineItem)).toContain("Tracking: Region=West, Team=Alpha");
+  });
+
+  it("renders empty tracking when undefined (no throw, no [object Object])", () => {
+    const lineItem = {
+      description: "Consulting",
+      lineAmount: 10,
+    } as LineItem;
+
+    const output = formatLineItem(lineItem);
+    expect(output).toContain("Tracking: ");
+    expect(output).not.toContain("[object Object]");
+  });
+
+  it("renders the item's itemID as a string, not [object Object]", () => {
+    const lineItem = {
+      itemCode: "ABC",
+      item: { code: "ABC", name: "Widget", itemID: "abc-123" },
+      lineAmount: 10,
+    } as LineItem;
+
+    const output = formatLineItem(lineItem);
+    expect(output).toContain("Item ID: abc-123");
+    expect(output).not.toContain("[object Object]");
+  });
+});

--- a/src/helpers/format-line-item.ts
+++ b/src/helpers/format-line-item.ts
@@ -1,15 +1,22 @@
 import { LineItem } from "xero-node";
 
+const formatTracking = (
+  tracking: LineItem["tracking"],
+): string =>
+  (tracking ?? [])
+    .map((t) => `${t.name}=${t.option}`)
+    .join(", ");
+
 export const formatLineItem = (lineItem: LineItem): string => {
   return [
-    `Item ID: ${lineItem.item}`,
+    `Item ID: ${lineItem.item?.itemID ?? ""}`,
     `Item Code: ${lineItem.itemCode}`,
     `Description: ${lineItem.description}`,
     `Quantity: ${lineItem.quantity}`,
     `Unit Amount: ${lineItem.unitAmount}`,
     `Account Code: ${lineItem.accountCode}`,
     `Tax Type: ${lineItem.taxType}`,
-    `Tracking: ${lineItem.tracking}`,
+    `Tracking: ${formatTracking(lineItem.tracking)}`,
     `Line Amount: ${lineItem.lineAmount}`,
   ].join("\n");
 };


### PR DESCRIPTION
## Problem

`list-invoices` (and `list-bank-transactions`, which share `formatLineItem`) render each line item's **tracking** and **item** fields as the literal string `[object Object]`:

```
Item ID: [object Object]
Item Code: ABC
...
Tracking: [object Object]
Line Amount: 100
```

`lineItem.tracking` is an `Array<LineItemTracking>` (`{name, option, trackingCategoryID, trackingOptionID}`) and `lineItem.item` is a `LineItemItem` object — both were interpolated directly into a template string, collapsing to `[object Object]`. Consumers can't see which tracking category/option is on an invoice without cross-referencing the tracking-categories endpoint.

## Fix

Formatting-only change in the shared `formatLineItem` helper:

- **Tracking** now renders as `name=option`, comma-separated (e.g. `Tracking: Region=West, Team=Alpha`), guarded against `undefined`/empty (tracking is optional; most bank-transaction and many invoice lines have none) so untracked lines print an empty value rather than throwing.
- **Item ID** now renders `item.itemID` as a string instead of the object.

After:
```
Item ID: 00000000-0000-0000-0000-000000000000
Item Code: ABC
...
Tracking: Region=West
Line Amount: 100
```

## Scope

`formatLineItem` is used by exactly two tools — `list-invoices` and `list-bank-transactions` — so this fixes both. `create-invoice`/`update-invoice` do not share this helper. No API call logic touched.

## Tests

Added unit tests for the tracking formatter (populated array, `undefined` no-throw guard) and the item field. Full suite: 17 passed.