### PR TITLE
fix: preserve 4dp precision for invoice unit amounts (#1Preserve 4dp precision for invoice unit amounts (fixes #157)57)

### DIFF
--- a/src/handlers/create-xero-invoice.handler.ts
+++ b/src/handlers/create-xero-invoice.handler.ts
@@ -45,7 +45,7 @@ async function createInvoice(
       invoices: [invoice],
     }, // invoices
     true, //summarizeErrors
-    undefined, //unitdp
+    4, // unitdp: preserve up to 4 decimal places for unit amounts (Xero rounds to 2dp by default)
     undefined, //idempotencyKey
     getClientHeaders(),
   );

--- a/src/handlers/update-xero-invoice.handler.ts
+++ b/src/handlers/update-xero-invoice.handler.ts
@@ -21,7 +21,7 @@ async function getInvoice(invoiceId: string): Promise<Invoice | undefined> {
   const response = await xeroClient.accountingApi.getInvoice(
     xeroClient.tenantId,
     invoiceId, // invoiceId
-    undefined, // unitdp
+    4, // unitdp: preserve up to 4 decimal places for unit amounts
     getClientHeaders(), // options
   );
 
@@ -50,7 +50,7 @@ async function updateInvoice(
     {
       invoices: [invoice],
     }, // invoices
-    undefined, // unitdp
+    4, // unitdp: preserve up to 4 decimal places for unit amounts (Xero rounds to 2dp by default)
     undefined, // idempotencyKey
     getClientHeaders(), // options
   );


### PR DESCRIPTION
Xero's createInvoices/updateInvoice/getInvoice API calls accept a unitdp query param controlling unit amount decimal precision. The MCP server was passing undefined, which makes Xero default to 2dp and round values like 0.1648 down to 0.16.

Energy/utilities billing commonly needs 4dp rates (e.g. $0.1648/kWh); rounding to 2dp causes invoice value discrepancies.
Fixes #157.

Change:
- Pass unitdp: 4 (instead of undefined) when calling the Xero Accounting API in create-xero-invoice.handler.ts and update-xero-invoice.handler.ts (both the getInvoice read and the updateOrCreateInvoices write).
This matches the documented Xero API behaviour: UnitAmount supports 4dp when the unitdp query parameter is explicitly set, otherwise it defaults to 2dp.