### PR TITLE
feat: allow update-invoice to set an invoice's status

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ payroll.timesheets
 - `create-tracking-option`: Create a new tracking option
 - `update-bank-transaction`: Update an existing bank transaction
 - `update-contact`: Update an existing contact
-- `update-invoice`: Update an existing draft invoice
+- `update-invoice`: Update an existing invoice or change its status
 - `update-item`: Update an existing item
 - `update-manual-journal`: Update an existing manual journal
 - `update-quote`: Update an existing draft quote

--- a/src/handlers/update-xero-invoice.handler.ts
+++ b/src/handlers/update-xero-invoice.handler.ts
@@ -35,6 +35,7 @@ async function updateInvoice(
   dueDate?: string,
   date?: string,
   contactId?: string,
+  status?: Invoice.StatusEnum,
 ): Promise<Invoice | undefined> {
   const invoice: Invoice = {
     lineItems: lineItems,
@@ -42,6 +43,7 @@ async function updateInvoice(
     dueDate: dueDate,
     date: date,
     contact: contactId ? { contactID: contactId } : undefined,
+    status: status,
   };
 
   const response = await xeroClient.accountingApi.updateInvoice(
@@ -58,6 +60,36 @@ async function updateInvoice(
   return response.body.invoices?.[0];
 }
 
+function formatAppliedEntityLabels(invoice: Invoice): string[] {
+  return [
+    invoice.payments?.length ? "payments" : null,
+    invoice.creditNotes?.length ? "credit notes" : null,
+    invoice.prepayments?.length ? "prepayments" : null,
+    invoice.overpayments?.length ? "overpayments" : null,
+  ].filter((label) => label !== null);
+}
+
+function formatRejectionReason(invoice: Invoice): string | undefined {
+  const status = invoice.status;
+
+  const isUpdatableStatus =
+    status === Invoice.StatusEnum.DRAFT ||
+    status === Invoice.StatusEnum.SUBMITTED ||
+    status === Invoice.StatusEnum.AUTHORISED;
+
+  if (!isUpdatableStatus) {
+    return `Cannot update invoice because its status is ${status}. Only draft, submitted and authorised invoices can be updated.`;
+  }
+
+  const applied = formatAppliedEntityLabels(invoice);
+
+  if (applied.length > 0) {
+    return `Cannot update invoice because it has ${applied.join(" and ")} applied to it. Remove them before updating the invoice.`;
+  }
+
+  return undefined;
+}
+
 /**
  * Update an existing invoice in Xero
  */
@@ -68,18 +100,22 @@ export async function updateXeroInvoice(
   dueDate?: string,
   date?: string,
   contactId?: string,
+  status?: Invoice.StatusEnum,
 ): Promise<XeroClientResponse<Invoice>> {
   try {
     const existingInvoice = await getInvoice(invoiceId);
 
-    const invoiceStatus = existingInvoice?.status;
+    if (!existingInvoice) {
+      throw new Error(`Could not find invoice ${invoiceId}`);
+    }
 
-    // Only allow updates to DRAFT invoices
-    if (invoiceStatus !== Invoice.StatusEnum.DRAFT) {
+    const rejectionReason = formatRejectionReason(existingInvoice);
+
+    if (rejectionReason) {
       return {
         result: null,
         isError: true,
-        error: `Cannot update invoice because it is not a draft. Current status: ${invoiceStatus}`,
+        error: rejectionReason,
       };
     }
 
@@ -90,6 +126,7 @@ export async function updateXeroInvoice(
       dueDate,
       date,
       contactId,
+      status,
     );
 
     if (!updatedInvoice) {

--- a/src/tools/update/update-invoice.tool.ts
+++ b/src/tools/update/update-invoice.tool.ts
@@ -27,16 +27,19 @@ const lineItemSchema = z.object({
 
 const UpdateInvoiceTool = CreateXeroTool(
   "update-invoice",
-  "Update an invoice in Xero. Only works on draft invoices.\
-  All line items must be provided. Any line items not provided will be removed. Including existing line items.\
+  "Update an invoice in Xero. Draft, submitted and authorised invoices can be updated.\
+  Omit lineItems to leave the invoice's line items untouched.\
+  When changing line items, all line items must be provided. Any line items not provided will be removed. Including existing line items.\
   Do not modify line items that have not been specified by the user.\
+  An authorised invoice can only be updated while it has no payments, credit notes, prepayments or overpayments applied.\
  When an invoice is updated, a deep link to the invoice in Xero is returned. \
  This deep link can be used to view the contact in Xero directly. \
  This link should be displayed to the user.",
   {
     invoiceId: z.string().describe("The ID of the invoice to update."),
     lineItems: z.array(lineItemSchema).optional().describe(
-      "All line items must be provided. Any line items not provided will be removed. Including existing line items. \
+      "Omit this argument to leave the invoice's line items untouched. \
+      When changing line items, all line items must be provided. Any line items not provided will be removed. Including existing line items. \
       Do not modify line items that have not been specified by the user",
     ),
     reference: z.string().optional().describe("A reference number for the invoice."),
@@ -44,6 +47,13 @@ const UpdateInvoiceTool = CreateXeroTool(
     date: z.string().optional().describe("The date of the invoice."),
     contactId: z.string().optional().describe("The ID of the contact to update the invoice for. \
       Can be obtained from the list-contacts tool."),
+    status: z.enum(["DRAFT", "SUBMITTED", "AUTHORISED", "DELETED", "VOIDED"]).optional().describe(
+      "The status to set on the invoice. SUBMITTED submits a draft invoice for approval, DRAFT \
+      returns a submitted invoice to draft, AUTHORISED approves a draft or submitted invoice, \
+      DELETED removes a draft or submitted invoice, and VOIDED cancels an authorised invoice that \
+      has no payments, credit notes, prepayments or overpayments applied. Omit to leave the status unchanged. \
+      Xero ignores every other field sent alongside DELETED or VOIDED, so send those on their own.",
+    ),
   },
   async (
     {
@@ -53,21 +63,8 @@ const UpdateInvoiceTool = CreateXeroTool(
       dueDate,
       date,
       contactId,
-    }: {
-      invoiceId: string;
-      lineItems?: Array<{
-        description: string;
-        quantity: number;
-        unitAmount: number;
-        accountCode: string;
-        taxType: string;
-      }>;
-      reference?: string;
-      dueDate?: string;
-      date?: string;
-      contactId?: string;
+      status,
     },
-    //_extra: { signal: AbortSignal },
   ) => {
     const result = await updateXeroInvoice(
       invoiceId,
@@ -76,6 +73,7 @@ const UpdateInvoiceTool = CreateXeroTool(
       dueDate,
       date,
       contactId,
+      status as Invoice.StatusEnum | undefined,
     );
     if (result.isError) {
       return {


### PR DESCRIPTION
Closes #220.

## What

`update-invoice` exposed no `status` parameter, and `update-xero-invoice.handler.ts` rejected every invoice whose status was not `DRAFT` before the SDK call was reached. Between them, an invoice's status could never be changed through the MCP: a caller could code a draft invoice or bill in full and then had to leave the MCP for the Xero web UI to approve it, or to dispose of a duplicate. Neither is an API limitation — Xero accepts `Status` on a POST to `/Invoices/{id}`, and `xero-node`'s `Invoice` already carries `status?: Invoice.StatusEnum`.

- **Tool** — adds an optional `status` enum (`DRAFT`, `SUBMITTED`, `AUTHORISED`, `DELETED`, `VOIDED`) and passes it through. `PAID` is not offered: it is reached by applying a payment, not by an update. The `z.enum` plus cast to `Invoice.StatusEnum` follows `update-manual-journal-tool.ts`, which already exposes a status this way.

- **Handler** — the `DRAFT`-only guard becomes `formatRejectionReason`, which answers one question: why, if at all, can this invoice not be updated? An invoice is updatable while its status is `DRAFT`, `SUBMITTED` or `AUTHORISED` **and** nothing is applied to it; a payment, credit note, prepayment or overpayment refuses the update with an error naming which of those it carries, and a terminal status refuses with the status in the message. The pre-flight `getInvoice` that already ran to read the status returns those four arrays as well, so the determination costs no extra call and is made *before* the write rather than inferred from a failed one.

- **Handler, not-found** — an empty `Invoices[]` from that pre-flight GET is now reported as *"Could not find invoice `<id>`"*, in the shape `update-xero-bank-transaction.handler.ts` already uses, instead of reaching the guard with an undefined status and being reported as a status problem. See the caveat below: this branch does **not** cover a 404 on an unknown id.

- **Tool callback** — the inline TypeScript annotation on the callback argument had drifted from the Zod schema: it omitted `itemCode` and `tracking`, so both were typed away at the handler boundary although the schema accepted them and they arrived at runtime. Rather than add `status` to a stale annotation it is dropped, so the schema infers the argument type — the shape `update-quote.tool.ts` already uses.

- **Descriptions and README** — the tool description and the `lineItems` parameter's own `.describe()` state the same rule and now state it consistently, each leading with the fact that closes the question: omitting `lineItems` leaves the invoice's line items untouched, and "all line items must be provided" is scoped to the case where they are being changed. The `status` `.describe()` documents all five values and warns that Xero ignores every other field sent alongside `DELETED` or `VOIDED`. `README.md:178` no longer describes the tool as draft-only.

## Where the guard's boundaries come from

Each boundary is Xero's rather than one this server invents, and each was established by driving the Accounting API directly, outside the guard, on throwaway fixtures in a real tenant:

| Current status | What Xero accepts | Guard |
|---|---|---|
| `DRAFT` | everything | updatable |
| `SUBMITTED` | line items, contact, date, due date, reference; moves on to `DRAFT`, `AUTHORISED` or `DELETED` | updatable |
| `AUTHORISED`, nothing applied | line items, contact, date, due date, reference, status — `ACCREC` and `ACCPAY` alike | updatable |
| `AUTHORISED` carrying a payment or an allocation | scalar fields; a line-item edit is refused unless each line carries a `LineItemID` | rejected, naming what is applied |
| `PAID`, `VOIDED`, `DELETED` | nothing, other than `PAID` → `VOIDED` | rejected, naming the status |

## What this deliberately does not do

Two of those rows are narrower than Xero, both on purpose rather than by oversight:

- **`PAID` → `VOIDED` is not offered.** Xero accepts it. Voiding an already-paid invoice is a larger accounting action than the rest of what this tool does, and the guard refusing it with a clear naming message is the intended behaviour.
- **An `AUTHORISED` invoice carrying a payment or an allocation is refused outright** — including a `reference` edit, which Xero does accept on a part-paid invoice. The guard asks one question about the invoice rather than maintaining a per-field allow-list. The divergence is confined to scalar fields: a line-item edit on a part-paid invoice is refused by Xero unless each line carries a `LineItemID`, and `lineItemSchema` has no such field, so that edit is not expressible through this tool either way.

Both are straightforward to relax if you would rather the wrapper stayed exactly as permissive as the API.

## A pre-existing caveat worth knowing about

Xero's own validation messages do not currently reach the caller. `xero-node` v13 rejects a non-2xx response with `reject(JSON.stringify(errorResponse.generateError()))` — a **string** — while `format-error.ts`'s `isXeroSdkError` requires an object with a numeric `response.statusCode`. A string matches neither that nor `instanceof Error`, so every Xero rejection falls through to *"An unexpected error occurred while communicating with Xero."*

This is pre-existing and untouched here — it behaves identically on `main` — but it bears on this change twice:

- The new not-found branch fires only when Xero returns **200 with an empty `Invoices[]`**. A well-formed but unknown invoice id makes Xero 404, and the caller gets the generic message instead. The branch is still worth having, but it is not a general "invoice not found" report.
- Now that callers drive status transitions by id, the transitions Xero itself refuses surface as that generic message rather than as Xero's explanation.

Happy to open a separate PR for `format-error.ts` if that would be welcome. Any fix there would need to preserve #173's whitelist discipline — its doc comment scopes the hazard to the SDK rejecting with a plain *object* carrying the caller's Bearer token, and whether the JSON-string shape carries a token too is not something I have established.

## Verification

- `npm run build`, `npm run lint` (`eslint .`) and `npm test` (**14 passed / 14**, 1 file) are green at the branch head.
- No tests added: this repo unit-tests pure helpers in `src/helpers/__tests__/`, and this change adds neither a helper there nor logic outside the handler. Both new functions are module-private with one call site each.
- Exercised against a real Xero tenant by driving the freshly-built `dist/` handlers and the tool object directly. Every fixture was a throwaway created and disposed of in the same run, with a closing sweep confirming none was left live. Each state below is an independent re-read from Xero, not a handler return value.

| Area | Result |
|---|---|
| `DRAFT` → `SUBMITTED` / `AUTHORISED` / `DELETED` | each applied |
| `SUBMITTED` → `DRAFT` / `AUTHORISED` / `DELETED`, plus a full field edit while `SUBMITTED` | all applied |
| unpaid, unallocated `AUTHORISED` → `VOIDED`, plus line-item, contact, date, due-date and reference edits, `ACCREC` and `ACCPAY` alike | all applied |
| `AUTHORISED` carrying a payment / a credit note / a prepayment | refused, naming what is applied; re-read confirms nothing was written |
| `PAID`, `VOIDED`, `DELETED` | refused, naming the status |
| `status` omitted | no `Status` key on the wire, and the outcome is identical to a build of `main` |
| `status: "APPROVED"` | rejected by the schema before any call |

Every status the tool can set was entered live and then left again or disposed of through the tool alone, so no value it offers strands an invoice in a state the tool can no longer manage.