### PR TITLE
feat: add purchase order tools (list, get, create, update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a Model Context Protocol (MCP) server implementation for Xero. It provid
 - Contact management
 - Chart of Accounts management
 - Invoice creation and management
+- Purchase order creation and management
 - MCP protocol compliance
 
 ## Prerequisites
@@ -146,6 +147,7 @@ payroll.timesheets
 - `list-organisation-details`: Retrieve details about an organisation
 - `list-profit-and-loss`: Retrieve a profit and loss report
 - `list-quotes`: Retrieve a list of quotes
+- `list-purchase-orders`: Retrieve a list of purchase orders
 - `list-tax-rates`: Retrieve a list of tax rates
 - `list-payments`: Retrieve a list of payments
 - `list-trial-balance`: Retrieve a trial balance report
@@ -170,6 +172,8 @@ payroll.timesheets
 - `create-manual-journal`: Create a new manual journal
 - `create-payment`: Create a new payment
 - `create-quote`: Create a new quote
+- `create-purchase-order`: Create a new draft purchase order
+- `get-purchase-order`: Retrieve a purchase order by ID or number
 - `create-payroll-timesheet`: Create a new Payroll Timesheet
 - `create-tracking-category`: Create a new tracking category
 - `create-tracking-option`: Create a new tracking option
@@ -179,6 +183,7 @@ payroll.timesheets
 - `update-item`: Update an existing item
 - `update-manual-journal`: Update an existing manual journal
 - `update-quote`: Update an existing draft quote
+- `update-purchase-order`: Update an existing draft or submitted purchase order
 - `update-credit-note`: Update an existing draft credit note
 - `update-tracking-category`: Update an existing tracking category
 - `update-tracking-options`: Update tracking options

--- a/src/consts/deeplinks.ts
+++ b/src/consts/deeplinks.ts
@@ -32,3 +32,10 @@ export const manualJournalDeepLink = (journalId: string) => {
 export const billDeepLink = (orgShortCode: string, billId: string) => {
   return `https://go.xero.com/organisationlogin/default.aspx?shortcode=${orgShortCode}&redirecturl=/AccountsPayable/Edit.aspx?InvoiceID=${billId}`;
 };
+
+export const purchaseOrderDeepLink = (
+  orgShortCode: string,
+  purchaseOrderId: string,
+) => {
+  return `https://go.xero.com/app/${orgShortCode}/purchase-orders/view/${purchaseOrderId}`;
+};

--- a/src/handlers/__tests__/mock-xero-client.ts
+++ b/src/handlers/__tests__/mock-xero-client.ts
@@ -1,0 +1,26 @@
+import { vi } from "vitest";
+
+export const mockAccountingApi = {
+  createPurchaseOrders: vi.fn(),
+  getPurchaseOrders: vi.fn(),
+  getPurchaseOrder: vi.fn(),
+  getPurchaseOrderByNumber: vi.fn(),
+  updatePurchaseOrder: vi.fn(),
+};
+
+export const mockXeroClient = {
+  authenticate: vi.fn().mockResolvedValue(undefined),
+  tenantId: "tenant-1",
+  accountingApi: mockAccountingApi,
+  getShortCode: vi.fn().mockResolvedValue("!abc"),
+};
+
+export function resetXeroClientMocks() {
+  mockXeroClient.authenticate.mockClear();
+  mockXeroClient.getShortCode.mockClear();
+  mockXeroClient.getShortCode.mockResolvedValue("!abc");
+  mockXeroClient.authenticate.mockResolvedValue(undefined);
+  for (const fn of Object.values(mockAccountingApi)) {
+    fn.mockReset();
+  }
+}

--- a/src/handlers/create-xero-purchase-order.handler.test.ts
+++ b/src/handlers/create-xero-purchase-order.handler.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { createXeroPurchaseOrder } from "./create-xero-purchase-order.handler.js";
+
+const lineItems = [
+  {
+    description: "Office chairs",
+    quantity: 2,
+    unitAmount: 150,
+    accountCode: "429",
+    taxType: "INPUT2",
+  },
+];
+
+const createdPurchaseOrder = {
+  purchaseOrderID: "po-1",
+  purchaseOrderNumber: "PO-1001",
+  status: "DRAFT",
+  total: 300,
+  contact: { contactID: "contact-1", name: "Northwind" },
+};
+
+describe("createXeroPurchaseOrder", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("creates a draft purchase order and returns it", async () => {
+    mockAccountingApi.createPurchaseOrders.mockResolvedValue({
+      body: { purchaseOrders: [createdPurchaseOrder] },
+    });
+
+    const result = await createXeroPurchaseOrder({
+      contactId: "contact-1",
+      lineItems,
+    });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result.purchaseOrderID).toBe("po-1");
+    expect(result.result.purchaseOrderNumber).toBe("PO-1001");
+    expect(mockXeroClient.authenticate).toHaveBeenCalledOnce();
+    expect(mockAccountingApi.createPurchaseOrders).toHaveBeenCalledWith(
+      "tenant-1",
+      {
+        purchaseOrders: [
+          expect.objectContaining({
+            contact: { contactID: "contact-1" },
+            lineItems,
+            status: "DRAFT",
+          }),
+        ],
+      },
+      true,
+      undefined,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+  });
+
+  it("passes optional delivery and reference fields through to Xero", async () => {
+    mockAccountingApi.createPurchaseOrders.mockResolvedValue({
+      body: { purchaseOrders: [createdPurchaseOrder] },
+    });
+
+    await createXeroPurchaseOrder({
+      contactId: "contact-1",
+      lineItems,
+      date: "2026-08-01",
+      deliveryDate: "2026-08-15",
+      reference: "JOB-44",
+      purchaseOrderNumber: "PO-CUSTOM",
+      deliveryAddress: "1 Warehouse Rd",
+      attentionTo: "Receiving",
+      telephone: "555-0100",
+      deliveryInstructions: "Leave at dock 2",
+    });
+
+    const payload = mockAccountingApi.createPurchaseOrders.mock.calls[0][1];
+    expect(payload.purchaseOrders[0]).toMatchObject({
+      date: "2026-08-01",
+      deliveryDate: "2026-08-15",
+      reference: "JOB-44",
+      purchaseOrderNumber: "PO-CUSTOM",
+      deliveryAddress: "1 Warehouse Rd",
+      attentionTo: "Receiving",
+      telephone: "555-0100",
+      deliveryInstructions: "Leave at dock 2",
+    });
+  });
+
+  it("returns a formatted error when Xero rejects the create", async () => {
+    mockAccountingApi.createPurchaseOrders.mockRejectedValue(
+      new Error("Contact is required"),
+    );
+
+    const result = await createXeroPurchaseOrder({
+      contactId: "missing",
+      lineItems,
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Contact is required",
+    });
+  });
+
+  it("returns an error when Xero returns no purchase order", async () => {
+    mockAccountingApi.createPurchaseOrders.mockResolvedValue({
+      body: { purchaseOrders: [] },
+    });
+
+    const result = await createXeroPurchaseOrder({
+      contactId: "contact-1",
+      lineItems,
+    });
+
+    expect(result.isError).toBe(true);
+    if (!result.isError) return;
+    expect(result.error).toBe("Purchase order creation failed.");
+  });
+});

--- a/src/handlers/create-xero-purchase-order.handler.ts
+++ b/src/handlers/create-xero-purchase-order.handler.ts
@@ -1,0 +1,80 @@
+import { PurchaseOrder } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { PurchaseOrderLineItem } from "../types/purchase-order.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface CreatePurchaseOrderParams {
+  contactId: string;
+  lineItems: PurchaseOrderLineItem[];
+  date?: string;
+  deliveryDate?: string;
+  reference?: string;
+  purchaseOrderNumber?: string;
+  deliveryAddress?: string;
+  attentionTo?: string;
+  telephone?: string;
+  deliveryInstructions?: string;
+}
+
+async function createPurchaseOrder(
+  params: CreatePurchaseOrderParams,
+): Promise<PurchaseOrder | undefined> {
+  await xeroClient.authenticate();
+
+  const purchaseOrder: PurchaseOrder = {
+    contact: {
+      contactID: params.contactId,
+    },
+    lineItems: params.lineItems,
+    date: params.date || new Date().toISOString().split("T")[0],
+    deliveryDate: params.deliveryDate,
+    reference: params.reference,
+    purchaseOrderNumber: params.purchaseOrderNumber,
+    deliveryAddress: params.deliveryAddress,
+    attentionTo: params.attentionTo,
+    telephone: params.telephone,
+    deliveryInstructions: params.deliveryInstructions,
+    status: PurchaseOrder.StatusEnum.DRAFT,
+  };
+
+  const response = await xeroClient.accountingApi.createPurchaseOrders(
+    xeroClient.tenantId,
+    {
+      purchaseOrders: [purchaseOrder],
+    },
+    true,
+    undefined,
+    getClientHeaders(),
+  );
+
+  return response.body.purchaseOrders?.[0];
+}
+
+/**
+ * Create a new purchase order in Xero
+ */
+export async function createXeroPurchaseOrder(
+  params: CreatePurchaseOrderParams,
+): Promise<XeroClientResponse<PurchaseOrder>> {
+  try {
+    const createdPurchaseOrder = await createPurchaseOrder(params);
+
+    if (!createdPurchaseOrder) {
+      throw new Error("Purchase order creation failed.");
+    }
+
+    return {
+      result: createdPurchaseOrder,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/get-xero-purchase-order.handler.test.ts
+++ b/src/handlers/get-xero-purchase-order.handler.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { getXeroPurchaseOrder } from "./get-xero-purchase-order.handler.js";
+
+const purchaseOrder = {
+  purchaseOrderID: "po-1",
+  purchaseOrderNumber: "PO-1001",
+  status: "DRAFT",
+  lineItems: [{ description: "Paper", quantity: 1, unitAmount: 10 }],
+};
+
+describe("getXeroPurchaseOrder", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("retrieves a purchase order by ID", async () => {
+    mockAccountingApi.getPurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [purchaseOrder] },
+    });
+
+    const result = await getXeroPurchaseOrder({ purchaseOrderId: "po-1" });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result.purchaseOrderID).toBe("po-1");
+    expect(mockAccountingApi.getPurchaseOrder).toHaveBeenCalledWith(
+      "tenant-1",
+      "po-1",
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+    expect(mockAccountingApi.getPurchaseOrderByNumber).not.toHaveBeenCalled();
+  });
+
+  it("retrieves a purchase order by number", async () => {
+    mockAccountingApi.getPurchaseOrderByNumber.mockResolvedValue({
+      body: { purchaseOrders: [purchaseOrder] },
+    });
+
+    const result = await getXeroPurchaseOrder({
+      purchaseOrderNumber: "PO-1001",
+    });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result.purchaseOrderNumber).toBe("PO-1001");
+    expect(mockAccountingApi.getPurchaseOrderByNumber).toHaveBeenCalledWith(
+      "tenant-1",
+      "PO-1001",
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("prefers ID when both ID and number are provided", async () => {
+    mockAccountingApi.getPurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [purchaseOrder] },
+    });
+
+    await getXeroPurchaseOrder({
+      purchaseOrderId: "po-1",
+      purchaseOrderNumber: "PO-1001",
+    });
+
+    expect(mockAccountingApi.getPurchaseOrder).toHaveBeenCalledOnce();
+    expect(mockAccountingApi.getPurchaseOrderByNumber).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when neither ID nor number is provided", async () => {
+    const result = await getXeroPurchaseOrder({});
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Provide a purchaseOrderId or purchaseOrderNumber.",
+    });
+    expect(mockAccountingApi.getPurchaseOrder).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when Xero returns no purchase order", async () => {
+    mockAccountingApi.getPurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [] },
+    });
+
+    const result = await getXeroPurchaseOrder({ purchaseOrderId: "missing" });
+
+    expect(result.isError).toBe(true);
+    if (!result.isError) return;
+    expect(result.error).toBe("Purchase order not found.");
+  });
+});

--- a/src/handlers/get-xero-purchase-order.handler.ts
+++ b/src/handlers/get-xero-purchase-order.handler.ts
@@ -1,0 +1,75 @@
+import { PurchaseOrder } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface GetPurchaseOrderParams {
+  purchaseOrderId?: string;
+  purchaseOrderNumber?: string;
+}
+
+async function fetchPurchaseOrder(
+  params: GetPurchaseOrderParams,
+): Promise<PurchaseOrder | undefined> {
+  await xeroClient.authenticate();
+
+  if (params.purchaseOrderId) {
+    const response = await xeroClient.accountingApi.getPurchaseOrder(
+      xeroClient.tenantId,
+      params.purchaseOrderId,
+      getClientHeaders(),
+    );
+    return response.body.purchaseOrders?.[0];
+  }
+
+  if (params.purchaseOrderNumber) {
+    const response = await xeroClient.accountingApi.getPurchaseOrderByNumber(
+      xeroClient.tenantId,
+      params.purchaseOrderNumber,
+      getClientHeaders(),
+    );
+    return response.body.purchaseOrders?.[0];
+  }
+
+  return undefined;
+}
+
+/**
+ * Retrieve a single purchase order from Xero
+ */
+export async function getXeroPurchaseOrder(
+  params: GetPurchaseOrderParams,
+): Promise<XeroClientResponse<PurchaseOrder>> {
+  try {
+    if (!params.purchaseOrderId && !params.purchaseOrderNumber) {
+      return {
+        result: null,
+        isError: true,
+        error: "Provide a purchaseOrderId or purchaseOrderNumber.",
+      };
+    }
+
+    const purchaseOrder = await fetchPurchaseOrder(params);
+
+    if (!purchaseOrder) {
+      return {
+        result: null,
+        isError: true,
+        error: "Purchase order not found.",
+      };
+    }
+
+    return {
+      result: purchaseOrder,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-purchase-orders.handler.test.ts
+++ b/src/handlers/list-xero-purchase-orders.handler.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { listXeroPurchaseOrders } from "./list-xero-purchase-orders.handler.js";
+
+const purchaseOrders = [
+  {
+    purchaseOrderID: "po-1",
+    purchaseOrderNumber: "PO-1001",
+    status: "AUTHORISED",
+    total: 120,
+  },
+];
+
+describe("listXeroPurchaseOrders", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("lists purchase orders for the first page by default", async () => {
+    mockAccountingApi.getPurchaseOrders.mockResolvedValue({
+      body: { purchaseOrders },
+    });
+
+    const result = await listXeroPurchaseOrders();
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toEqual(purchaseOrders);
+    expect(mockAccountingApi.getPurchaseOrders).toHaveBeenCalledWith(
+      "tenant-1",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      1,
+      10,
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("forwards status and date filters", async () => {
+    mockAccountingApi.getPurchaseOrders.mockResolvedValue({
+      body: { purchaseOrders },
+    });
+
+    await listXeroPurchaseOrders({
+      page: 2,
+      status: "DRAFT",
+      dateFrom: "2026-01-01",
+      dateTo: "2026-01-31",
+    });
+
+    expect(mockAccountingApi.getPurchaseOrders).toHaveBeenCalledWith(
+      "tenant-1",
+      undefined,
+      "DRAFT",
+      "2026-01-01",
+      "2026-01-31",
+      undefined,
+      2,
+      10,
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("returns an empty list when Xero omits purchaseOrders", async () => {
+    mockAccountingApi.getPurchaseOrders.mockResolvedValue({ body: {} });
+
+    const result = await listXeroPurchaseOrders({ page: 1 });
+
+    expect(result).toEqual({
+      result: [],
+      isError: false,
+      error: null,
+    });
+  });
+
+  it("returns a formatted error when the list call fails", async () => {
+    mockAccountingApi.getPurchaseOrders.mockRejectedValue(
+      new Error("rate limited"),
+    );
+
+    const result = await listXeroPurchaseOrders({ page: 1 });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "rate limited",
+    });
+  });
+});

--- a/src/handlers/list-xero-purchase-orders.handler.ts
+++ b/src/handlers/list-xero-purchase-orders.handler.ts
@@ -1,0 +1,56 @@
+import { PurchaseOrder } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { PurchaseOrderStatus } from "../types/purchase-order.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface ListPurchaseOrdersParams {
+  page?: number;
+  status?: PurchaseOrderStatus;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+async function getPurchaseOrders(
+  params: ListPurchaseOrdersParams,
+): Promise<PurchaseOrder[]> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getPurchaseOrders(
+    xeroClient.tenantId,
+    undefined,
+    params.status,
+    params.dateFrom,
+    params.dateTo,
+    undefined,
+    params.page ?? 1,
+    10,
+    getClientHeaders(),
+  );
+
+  return response.body.purchaseOrders ?? [];
+}
+
+/**
+ * List purchase orders from Xero
+ */
+export async function listXeroPurchaseOrders(
+  params: ListPurchaseOrdersParams = {},
+): Promise<XeroClientResponse<PurchaseOrder[]>> {
+  try {
+    const purchaseOrders = await getPurchaseOrders(params);
+
+    return {
+      result: purchaseOrders,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/update-xero-purchase-order.handler.test.ts
+++ b/src/handlers/update-xero-purchase-order.handler.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { updateXeroPurchaseOrder } from "./update-xero-purchase-order.handler.js";
+
+const existingDraft = {
+  purchaseOrderID: "po-1",
+  status: "DRAFT",
+  contact: { contactID: "contact-1", name: "Northwind" },
+};
+
+const updatedPurchaseOrder = {
+  ...existingDraft,
+  reference: "JOB-99",
+  total: 80,
+};
+
+describe("updateXeroPurchaseOrder", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("updates a draft purchase order", async () => {
+    mockAccountingApi.getPurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [existingDraft] },
+    });
+    mockAccountingApi.updatePurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [updatedPurchaseOrder] },
+    });
+
+    const result = await updateXeroPurchaseOrder({
+      purchaseOrderId: "po-1",
+      reference: "JOB-99",
+      lineItems: [
+        {
+          description: "Toner",
+          quantity: 1,
+          unitAmount: 80,
+          accountCode: "429",
+          taxType: "INPUT2",
+        },
+      ],
+    });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result.reference).toBe("JOB-99");
+    expect(mockAccountingApi.updatePurchaseOrder).toHaveBeenCalledWith(
+      "tenant-1",
+      "po-1",
+      {
+        purchaseOrders: [
+          expect.objectContaining({
+            reference: "JOB-99",
+            lineItems: [
+              expect.objectContaining({ description: "Toner", unitAmount: 80 }),
+            ],
+          }),
+        ],
+      },
+      undefined,
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("allows updates to submitted purchase orders", async () => {
+    mockAccountingApi.getPurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [{ ...existingDraft, status: "SUBMITTED" }] },
+    });
+    mockAccountingApi.updatePurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [updatedPurchaseOrder] },
+    });
+
+    const result = await updateXeroPurchaseOrder({
+      purchaseOrderId: "po-1",
+      deliveryInstructions: "Call on arrival",
+    });
+
+    expect(result.isError).toBe(false);
+  });
+
+  it("rejects billed purchase orders", async () => {
+    mockAccountingApi.getPurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [{ ...existingDraft, status: "BILLED" }] },
+    });
+
+    const result = await updateXeroPurchaseOrder({
+      purchaseOrderId: "po-1",
+      reference: "nope",
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error:
+        "Cannot update purchase order because it is BILLED. Only DRAFT and SUBMITTED purchase orders can be updated.",
+    });
+    expect(mockAccountingApi.updatePurchaseOrder).not.toHaveBeenCalled();
+  });
+
+  it("rejects deleted purchase orders", async () => {
+    mockAccountingApi.getPurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [{ ...existingDraft, status: "DELETED" }] },
+    });
+
+    const result = await updateXeroPurchaseOrder({
+      purchaseOrderId: "po-1",
+      reference: "nope",
+    });
+
+    expect(result.isError).toBe(true);
+    if (!result.isError) return;
+    expect(result.error).toContain("DELETED");
+  });
+
+  it("can authorise a draft purchase order", async () => {
+    mockAccountingApi.getPurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [existingDraft] },
+    });
+    mockAccountingApi.updatePurchaseOrder.mockResolvedValue({
+      body: {
+        purchaseOrders: [{ ...existingDraft, status: "AUTHORISED" }],
+      },
+    });
+
+    const result = await updateXeroPurchaseOrder({
+      purchaseOrderId: "po-1",
+      status: "AUTHORISED",
+    });
+
+    expect(result.isError).toBe(false);
+    const payload = mockAccountingApi.updatePurchaseOrder.mock.calls[0][2];
+    expect(payload.purchaseOrders[0].status).toBe("AUTHORISED");
+  });
+
+  it("returns an error when the existing purchase order cannot be loaded", async () => {
+    mockAccountingApi.getPurchaseOrder.mockResolvedValue({
+      body: { purchaseOrders: [] },
+    });
+
+    const result = await updateXeroPurchaseOrder({
+      purchaseOrderId: "missing",
+      reference: "x",
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Purchase order not found.",
+    });
+  });
+});

--- a/src/handlers/update-xero-purchase-order.handler.ts
+++ b/src/handlers/update-xero-purchase-order.handler.ts
@@ -1,0 +1,119 @@
+import { PurchaseOrder } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import {
+  PurchaseOrderLineItem,
+  PurchaseOrderStatus,
+  UPDATABLE_PURCHASE_ORDER_STATUSES,
+} from "../types/purchase-order.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface UpdatePurchaseOrderParams {
+  purchaseOrderId: string;
+  lineItems?: PurchaseOrderLineItem[];
+  date?: string;
+  deliveryDate?: string;
+  reference?: string;
+  purchaseOrderNumber?: string;
+  deliveryAddress?: string;
+  attentionTo?: string;
+  telephone?: string;
+  deliveryInstructions?: string;
+  contactId?: string;
+  status?: PurchaseOrderStatus;
+}
+
+async function getPurchaseOrder(
+  purchaseOrderId: string,
+): Promise<PurchaseOrder | undefined> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getPurchaseOrder(
+    xeroClient.tenantId,
+    purchaseOrderId,
+    getClientHeaders(),
+  );
+
+  return response.body.purchaseOrders?.[0];
+}
+
+async function updatePurchaseOrder(
+  params: UpdatePurchaseOrderParams,
+): Promise<PurchaseOrder | undefined> {
+  const purchaseOrder: PurchaseOrder = {
+    lineItems: params.lineItems,
+    date: params.date,
+    deliveryDate: params.deliveryDate,
+    reference: params.reference,
+    purchaseOrderNumber: params.purchaseOrderNumber,
+    deliveryAddress: params.deliveryAddress,
+    attentionTo: params.attentionTo,
+    telephone: params.telephone,
+    deliveryInstructions: params.deliveryInstructions,
+    contact: params.contactId ? { contactID: params.contactId } : undefined,
+    status: params.status as PurchaseOrder.StatusEnum | undefined,
+  };
+
+  const response = await xeroClient.accountingApi.updatePurchaseOrder(
+    xeroClient.tenantId,
+    params.purchaseOrderId,
+    {
+      purchaseOrders: [purchaseOrder],
+    },
+    undefined,
+    getClientHeaders(),
+  );
+
+  return response.body.purchaseOrders?.[0];
+}
+
+/**
+ * Update an existing draft or submitted purchase order in Xero
+ */
+export async function updateXeroPurchaseOrder(
+  params: UpdatePurchaseOrderParams,
+): Promise<XeroClientResponse<PurchaseOrder>> {
+  try {
+    const existing = await getPurchaseOrder(params.purchaseOrderId);
+
+    if (!existing) {
+      return {
+        result: null,
+        isError: true,
+        error: "Purchase order not found.",
+      };
+    }
+
+    const currentStatus = existing.status as PurchaseOrderStatus | undefined;
+
+    if (
+      !currentStatus ||
+      !UPDATABLE_PURCHASE_ORDER_STATUSES.includes(currentStatus)
+    ) {
+      return {
+        result: null,
+        isError: true,
+        error: `Cannot update purchase order because it is ${currentStatus ?? "unknown"}. Only DRAFT and SUBMITTED purchase orders can be updated.`,
+      };
+    }
+
+    const updatedPurchaseOrder = await updatePurchaseOrder(params);
+
+    if (!updatedPurchaseOrder) {
+      throw new Error("Purchase order update failed.");
+    }
+
+    return {
+      result: updatedPurchaseOrder,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/helpers/__tests__/format-purchase-order.test.ts
+++ b/src/helpers/__tests__/format-purchase-order.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { formatPurchaseOrder } from "../format-purchase-order.js";
+
+describe("formatPurchaseOrder", () => {
+  it("formats core purchase order fields and omits missing optionals", () => {
+    const text = formatPurchaseOrder({
+      purchaseOrderID: "po-1",
+      purchaseOrderNumber: "PO-1001",
+      status: "DRAFT" as never,
+      total: 25,
+      contact: { contactID: "c-1", name: "Northwind" },
+    });
+
+    expect(text).toContain("ID: po-1");
+    expect(text).toContain("Number: PO-1001");
+    expect(text).toContain("Status: DRAFT");
+    expect(text).toContain("Contact: Northwind (c-1)");
+    expect(text).toContain("Total: 25");
+    expect(text).not.toContain("Reference:");
+    expect(text).not.toContain("Line Items:");
+  });
+
+  it("includes line items when requested", () => {
+    const text = formatPurchaseOrder(
+      {
+        purchaseOrderID: "po-1",
+        lineItems: [
+          {
+            description: "Paper",
+            quantity: 2,
+            unitAmount: 5,
+            accountCode: "429",
+            taxType: "INPUT2",
+            lineAmount: 10,
+          },
+        ],
+      },
+      { includeLineItems: true },
+    );
+
+    expect(text).toContain("Line Items:");
+    expect(text).toContain("Description: Paper");
+    expect(text).toContain("Quantity: 2");
+  });
+});

--- a/src/helpers/__tests__/get-deeplink.test.ts
+++ b/src/helpers/__tests__/get-deeplink.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "../../handlers/__tests__/mock-xero-client.js";
+
+vi.mock("../../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { DeepLinkType, getDeepLink } from "../get-deeplink.js";
+
+describe("getDeepLink", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("builds a purchase order deep link from the org short code", async () => {
+    const link = await getDeepLink(DeepLinkType.PURCHASE_ORDER, "po-1");
+    expect(link).toBe("https://go.xero.com/app/!abc/purchase-orders/view/po-1");
+  });
+});

--- a/src/helpers/__tests__/vitest-setup.ts
+++ b/src/helpers/__tests__/vitest-setup.ts
@@ -1,0 +1,2 @@
+process.env.XERO_CLIENT_ID ??= "test-client-id";
+process.env.XERO_CLIENT_SECRET ??= "test-client-secret";

--- a/src/helpers/format-purchase-order.ts
+++ b/src/helpers/format-purchase-order.ts
@@ -1,0 +1,54 @@
+import { PurchaseOrder } from "xero-node";
+import { formatLineItem } from "./format-line-item.js";
+
+export const formatPurchaseOrder = (
+  purchaseOrder: PurchaseOrder,
+  options?: { includeLineItems?: boolean },
+): string => {
+  return [
+    `ID: ${purchaseOrder.purchaseOrderID}`,
+    purchaseOrder.purchaseOrderNumber
+      ? `Number: ${purchaseOrder.purchaseOrderNumber}`
+      : null,
+    purchaseOrder.reference ? `Reference: ${purchaseOrder.reference}` : null,
+    `Status: ${purchaseOrder.status || "Unknown"}`,
+    purchaseOrder.contact
+      ? `Contact: ${purchaseOrder.contact.name} (${purchaseOrder.contact.contactID})`
+      : null,
+    purchaseOrder.date ? `Date: ${purchaseOrder.date}` : null,
+    purchaseOrder.deliveryDate
+      ? `Delivery Date: ${purchaseOrder.deliveryDate}`
+      : null,
+    purchaseOrder.deliveryAddress
+      ? `Delivery Address: ${purchaseOrder.deliveryAddress}`
+      : null,
+    purchaseOrder.attentionTo
+      ? `Attention To: ${purchaseOrder.attentionTo}`
+      : null,
+    purchaseOrder.telephone ? `Telephone: ${purchaseOrder.telephone}` : null,
+    purchaseOrder.deliveryInstructions
+      ? `Delivery Instructions: ${purchaseOrder.deliveryInstructions}`
+      : null,
+    purchaseOrder.lineAmountTypes
+      ? `Line Amount Types: ${purchaseOrder.lineAmountTypes}`
+      : null,
+    purchaseOrder.subTotal != null
+      ? `Sub Total: ${purchaseOrder.subTotal}`
+      : null,
+    purchaseOrder.totalTax != null
+      ? `Total Tax: ${purchaseOrder.totalTax}`
+      : null,
+    `Total: ${purchaseOrder.total || 0}`,
+    purchaseOrder.currencyCode
+      ? `Currency: ${purchaseOrder.currencyCode}`
+      : null,
+    purchaseOrder.updatedDateUTC
+      ? `Last Updated: ${purchaseOrder.updatedDateUTC}`
+      : null,
+    options?.includeLineItems
+      ? `Line Items:\n${purchaseOrder.lineItems?.map(formatLineItem).join("\n---\n") || "None"}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+};

--- a/src/helpers/get-deeplink.ts
+++ b/src/helpers/get-deeplink.ts
@@ -7,6 +7,7 @@ import {
   manualJournalDeepLink,
   quoteDeepLink,
   billDeepLink,
+  purchaseOrderDeepLink,
 } from "../consts/deeplinks.js";
 
 export enum DeepLinkType {
@@ -17,6 +18,7 @@ export enum DeepLinkType {
   QUOTE,
   PAYMENT,
   BILL,
+  PURCHASE_ORDER,
 }
 
 /**
@@ -48,5 +50,7 @@ export const getDeepLink = async (type: DeepLinkType, itemId: string) => {
       return paymentDeepLink(orgShortCode, itemId);
     case DeepLinkType.BILL:
       return billDeepLink(orgShortCode, itemId);
+    case DeepLinkType.PURCHASE_ORDER:
+      return purchaseOrderDeepLink(orgShortCode, itemId);
   }
 };

--- a/src/tools/create/create-purchase-order.tool.ts
+++ b/src/tools/create/create-purchase-order.tool.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+import { createXeroPurchaseOrder } from "../../handlers/create-xero-purchase-order.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatPurchaseOrder } from "../../helpers/format-purchase-order.js";
+import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
+
+const trackingSchema = z.object({
+  name: z
+    .string()
+    .describe(
+      "The name of the tracking category. Can be obtained from the list-tracking-categories tool",
+    ),
+  option: z
+    .string()
+    .describe(
+      "The name of the tracking option. Can be obtained from the list-tracking-categories tool",
+    ),
+  trackingCategoryID: z
+    .string()
+    .describe(
+      "The ID of the tracking category. Can be obtained from the list-tracking-categories tool",
+    ),
+});
+
+const lineItemSchema = z.object({
+  description: z.string().describe("The description of the line item"),
+  quantity: z.number().describe("The quantity of the line item"),
+  unitAmount: z.number().describe("The price per unit of the line item"),
+  accountCode: z
+    .string()
+    .describe(
+      "The account code of the line item - can be obtained from the list-accounts tool",
+    ),
+  taxType: z
+    .string()
+    .describe(
+      "The tax type of the line item - can be obtained from the list-tax-rates tool",
+    ),
+  itemCode: z
+    .string()
+    .describe(
+      "The item code of the line item - can be obtained from the list-items tool. \
+If the item is not listed, add without an item code and ask the user if they would like to add an item code.",
+    )
+    .optional(),
+  tracking: z
+    .array(trackingSchema)
+    .describe(
+      "Up to 2 tracking categories and options can be added to the line item. \
+Can be obtained from the list-tracking-categories tool. Only use if prompted by the user.",
+    )
+    .optional(),
+});
+
+const CreatePurchaseOrderTool = CreateXeroTool(
+  "create-purchase-order",
+  "Create a draft purchase order in Xero. \
+When a purchase order is created, a deep link to the purchase order in Xero is returned. \
+This deep link can be used to view the purchase order in Xero directly. \
+This link should be displayed to the user.",
+  {
+    contactId: z
+      .string()
+      .describe(
+        "The ID of the supplier contact to create the purchase order for. \
+Can be obtained from the list-contacts tool.",
+      ),
+    lineItems: z.array(lineItemSchema),
+    date: z
+      .string()
+      .describe("The date the purchase order was issued (YYYY-MM-DD).")
+      .optional(),
+    deliveryDate: z
+      .string()
+      .describe("The date the goods are to be delivered (YYYY-MM-DD).")
+      .optional(),
+    reference: z
+      .string()
+      .describe("An additional reference number for the purchase order.")
+      .optional(),
+    purchaseOrderNumber: z
+      .string()
+      .describe(
+        "A custom purchase order number. If omitted, Xero generates one from organisation invoice settings.",
+      )
+      .optional(),
+    deliveryAddress: z
+      .string()
+      .describe("The address the goods are to be delivered to.")
+      .optional(),
+    attentionTo: z
+      .string()
+      .describe("The person that the delivery is going to.")
+      .optional(),
+    telephone: z
+      .string()
+      .describe("The phone number for the person accepting the delivery.")
+      .optional(),
+    deliveryInstructions: z
+      .string()
+      .describe("Free-text delivery instructions (500 characters max).")
+      .optional(),
+  },
+  async (params) => {
+    const result = await createXeroPurchaseOrder(params);
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error creating purchase order: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    const purchaseOrder = result.result;
+    const deepLink = purchaseOrder.purchaseOrderID
+      ? await getDeepLink(
+          DeepLinkType.PURCHASE_ORDER,
+          purchaseOrder.purchaseOrderID,
+        )
+      : null;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Purchase order created successfully:",
+            formatPurchaseOrder(purchaseOrder),
+            deepLink ? `Link to view: ${deepLink}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default CreatePurchaseOrderTool;

--- a/src/tools/create/index.ts
+++ b/src/tools/create/index.ts
@@ -6,6 +6,7 @@ import CreateItemTool from "./create-item.tool.js";
 import CreateManualJournalTool from "./create-manual-journal.tool.js";
 import CreatePaymentTool from "./create-payment.tool.js";
 import CreatePayrollTimesheetTool from "./create-payroll-timesheet.tool.js";
+import CreatePurchaseOrderTool from "./create-purchase-order.tool.js";
 import CreateQuoteTool from "./create-quote.tool.js";
 import CreateTrackingCategoryTool from "./create-tracking-category.tool.js";
 import CreateTrackingOptionsTool from "./create-tracking-options.tool.js";
@@ -15,6 +16,7 @@ export const CreateTools = [
   CreateCreditNoteTool,
   CreateManualJournalTool,
   CreateInvoiceTool,
+  CreatePurchaseOrderTool,
   CreateQuoteTool,
   CreatePaymentTool,
   CreateItemTool,

--- a/src/tools/get/get-purchase-order.tool.ts
+++ b/src/tools/get/get-purchase-order.tool.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import { getXeroPurchaseOrder } from "../../handlers/get-xero-purchase-order.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatPurchaseOrder } from "../../helpers/format-purchase-order.js";
+import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
+
+const GetPurchaseOrderTool = CreateXeroTool(
+  "get-purchase-order",
+  `Retrieve a single purchase order from Xero by ID or purchase order number.
+  Provide purchaseOrderId or purchaseOrderNumber. If both are provided, the ID is used.
+  Line items and a deep link are included in the response.`,
+  {
+    purchaseOrderId: z
+      .string()
+      .optional()
+      .describe("The ID of the purchase order to retrieve."),
+    purchaseOrderNumber: z
+      .string()
+      .optional()
+      .describe(
+        "The purchase order number (for example PO-1001). Used when the ID is not available.",
+      ),
+  },
+  async ({ purchaseOrderId, purchaseOrderNumber }) => {
+    const response = await getXeroPurchaseOrder({
+      purchaseOrderId,
+      purchaseOrderNumber,
+    });
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error retrieving purchase order: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const purchaseOrder = response.result;
+    const deepLink = purchaseOrder.purchaseOrderID
+      ? await getDeepLink(
+          DeepLinkType.PURCHASE_ORDER,
+          purchaseOrder.purchaseOrderID,
+        )
+      : null;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            formatPurchaseOrder(purchaseOrder, { includeLineItems: true }),
+            deepLink ? `Link to view: ${deepLink}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default GetPurchaseOrderTool;

--- a/src/tools/get/index.ts
+++ b/src/tools/get/index.ts
@@ -1,5 +1,7 @@
 import GetPayrollTimesheetTool from "./get-payroll-timesheet.tool.js";
+import GetPurchaseOrderTool from "./get-purchase-order.tool.js";
 
 export const GetTools = [
   GetPayrollTimesheetTool,
+  GetPurchaseOrderTool,
 ];

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -22,6 +22,7 @@ import ListPayrollLeavePeriodsToolTool
 import ListPayrollLeaveTypesTool from "./list-payroll-leave-types.tool.js";
 import ListPayrollTimesheetsTool from "./list-payroll-timesheets.tool.js";
 import ListProfitAndLossTool from "./list-profit-and-loss.tool.js";
+import ListPurchaseOrdersTool from "./list-purchase-orders.tool.js";
 import ListQuotesTool from "./list-quotes.tool.js";
 import ListReportBalanceSheetTool from "./list-report-balance-sheet.tool.js";
 import ListTaxRatesTool from "./list-tax-rates.tool.js";
@@ -36,6 +37,7 @@ export const ListTools = [
   ListInvoicesTool,
   ListItemsTool,
   ListManualJournalsTool,
+  ListPurchaseOrdersTool,
   ListQuotesTool,
   ListTaxRatesTool,
   ListTrialBalanceTool,

--- a/src/tools/list/list-purchase-orders.tool.ts
+++ b/src/tools/list/list-purchase-orders.tool.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { listXeroPurchaseOrders } from "../../handlers/list-xero-purchase-orders.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatPurchaseOrder } from "../../helpers/format-purchase-order.js";
+
+const ListPurchaseOrdersTool = CreateXeroTool(
+  "list-purchase-orders",
+  `List purchase orders in Xero.
+  Ask the user if they want to filter by status or date range before running.
+  Ask the user if they want the next page of purchase orders after running this tool if 10 purchase orders are returned.
+  If they do, call this tool again with the next page number and the same filters.`,
+  {
+    page: z.number().describe("The page of purchase orders to retrieve."),
+    status: z
+      .enum(["DRAFT", "SUBMITTED", "AUTHORISED", "BILLED", "DELETED"])
+      .optional()
+      .describe("Filter by purchase order status."),
+    dateFrom: z
+      .string()
+      .optional()
+      .describe("Filter purchase orders issued on or after this date (YYYY-MM-DD)."),
+    dateTo: z
+      .string()
+      .optional()
+      .describe("Filter purchase orders issued on or before this date (YYYY-MM-DD)."),
+  },
+  async ({ page, status, dateFrom, dateTo }) => {
+    const response = await listXeroPurchaseOrders({
+      page,
+      status,
+      dateFrom,
+      dateTo,
+    });
+    if (response.error !== null) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing purchase orders: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const purchaseOrders = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${purchaseOrders?.length || 0} purchase orders:`,
+        },
+        ...(purchaseOrders?.map((purchaseOrder) => ({
+          type: "text" as const,
+          text: formatPurchaseOrder(purchaseOrder),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPurchaseOrdersTool;

--- a/src/tools/tool-factory.test.ts
+++ b/src/tools/tool-factory.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { CreateTools } from "./create/index.js";
+import { GetTools } from "./get/index.js";
+import { ListTools } from "./list/index.js";
+import { UpdateTools } from "./update/index.js";
+
+describe("purchase order tools are registered", () => {
+  it("includes create, list, get, and update purchase order tools", () => {
+    const names = [
+      ...CreateTools,
+      ...ListTools,
+      ...GetTools,
+      ...UpdateTools,
+    ].map((tool) => tool().name);
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "create-purchase-order",
+        "list-purchase-orders",
+        "get-purchase-order",
+        "update-purchase-order",
+      ]),
+    );
+  });
+});

--- a/src/tools/update/index.ts
+++ b/src/tools/update/index.ts
@@ -9,6 +9,7 @@ import AddTimesheetLineTool from "./update-payroll-timesheet-add-line.tool.js";
 import UpdatePayrollTimesheetLineTool
   from "./update-payroll-timesheet-update-line.tool.js";
 import UpdateManualJournalTool from "./update-manual-journal-tool.js";
+import UpdatePurchaseOrderTool from "./update-purchase-order.tool.js";
 import UpdateQuoteTool from "./update-quote.tool.js";
 import UpdateTrackingCategoryTool from "./update-tracking-category.tool.js";
 import UpdateTrackingOptionsTool from "./update-tracking-options.tool.js";
@@ -18,6 +19,7 @@ export const UpdateTools = [
   UpdateCreditNoteTool,
   UpdateInvoiceTool,
   UpdateManualJournalTool,
+  UpdatePurchaseOrderTool,
   UpdateQuoteTool,
   UpdateItemTool,
   UpdateBankTransactionTool,

--- a/src/tools/update/update-purchase-order.tool.ts
+++ b/src/tools/update/update-purchase-order.tool.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import { updateXeroPurchaseOrder } from "../../handlers/update-xero-purchase-order.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatPurchaseOrder } from "../../helpers/format-purchase-order.js";
+import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
+
+const trackingSchema = z.object({
+  name: z.string().describe("The name of the tracking category."),
+  option: z.string().describe("The name of the tracking option."),
+  trackingCategoryID: z.string().describe("The ID of the tracking category."),
+});
+
+const lineItemSchema = z.object({
+  description: z.string().describe("The description of the line item"),
+  quantity: z.number().describe("The quantity of the line item"),
+  unitAmount: z.number().describe("The price per unit of the line item"),
+  accountCode: z
+    .string()
+    .describe(
+      "The account code of the line item - can be obtained from the list-accounts tool",
+    ),
+  taxType: z
+    .string()
+    .describe(
+      "The tax type of the line item - can be obtained from the list-tax-rates tool",
+    ),
+  itemCode: z.string().optional(),
+  tracking: z.array(trackingSchema).optional(),
+});
+
+const UpdatePurchaseOrderTool = CreateXeroTool(
+  "update-purchase-order",
+  "Update a purchase order in Xero. Only works on DRAFT and SUBMITTED purchase orders. \
+  All line items must be provided when changing lines. Any line items not provided will be removed. \
+  Do not modify line items that have not been specified by the user. \
+  Use status AUTHORISED to approve a purchase order, or DELETED to delete a draft/submitted one. \
+  When a purchase order is updated, a deep link to the purchase order in Xero is returned. \
+  This link should be displayed to the user.",
+  {
+    purchaseOrderId: z
+      .string()
+      .describe("The ID of the purchase order to update."),
+    lineItems: z
+      .array(lineItemSchema)
+      .optional()
+      .describe(
+        "All line items must be provided. Any line items not provided will be removed. \
+Do not modify line items that have not been specified by the user.",
+      ),
+    date: z
+      .string()
+      .optional()
+      .describe("The date the purchase order was issued (YYYY-MM-DD)."),
+    deliveryDate: z
+      .string()
+      .optional()
+      .describe("The date the goods are to be delivered (YYYY-MM-DD)."),
+    reference: z.string().optional(),
+    purchaseOrderNumber: z.string().optional(),
+    deliveryAddress: z.string().optional(),
+    attentionTo: z.string().optional(),
+    telephone: z.string().optional(),
+    deliveryInstructions: z.string().optional(),
+    contactId: z
+      .string()
+      .optional()
+      .describe("Replace the supplier contact on the purchase order."),
+    status: z
+      .enum(["DRAFT", "SUBMITTED", "AUTHORISED", "DELETED"])
+      .optional()
+      .describe(
+        "New status. AUTHORISED approves the purchase order. DELETED deletes a draft or submitted purchase order.",
+      ),
+  },
+  async (params) => {
+    const result = await updateXeroPurchaseOrder(params);
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error updating purchase order: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    const purchaseOrder = result.result;
+    const deepLink = purchaseOrder.purchaseOrderID
+      ? await getDeepLink(
+          DeepLinkType.PURCHASE_ORDER,
+          purchaseOrder.purchaseOrderID,
+        )
+      : null;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Purchase order updated successfully:",
+            formatPurchaseOrder(purchaseOrder),
+            deepLink ? `Link to view: ${deepLink}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default UpdatePurchaseOrderTool;

--- a/src/types/purchase-order.ts
+++ b/src/types/purchase-order.ts
@@ -1,0 +1,23 @@
+import { LineItemTracking } from "xero-node";
+
+export interface PurchaseOrderLineItem {
+  description: string;
+  quantity: number;
+  unitAmount: number;
+  accountCode: string;
+  taxType: string;
+  itemCode?: string;
+  tracking?: LineItemTracking[];
+}
+
+export type PurchaseOrderStatus =
+  | "DRAFT"
+  | "SUBMITTED"
+  | "AUTHORISED"
+  | "BILLED"
+  | "DELETED";
+
+export const UPDATABLE_PURCHASE_ORDER_STATUSES: PurchaseOrderStatus[] = [
+  "DRAFT",
+  "SUBMITTED",
+];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    setupFiles: ["src/helpers/__tests__/vitest-setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Adds MCP tools for Xero purchase orders so agents can run a full draft-to-authorise PO workflow without leaving the server.

Closes #90.

### Tools
- `create-purchase-order` — create a draft PO with line items and optional delivery details
- `list-purchase-orders` — page through POs, with optional status and date filters
- `get-purchase-order` — fetch one PO by ID or PO number, including line items
- `update-purchase-order` — update DRAFT/SUBMITTED POs, or set status to `AUTHORISED` / `DELETED`

Each write tool returns a deep link into the Xero UI.

Purchase orders are already covered by existing scopes (`accounting.transactions` on older custom connections, `accounting.invoices` on granular V2 apps), so no scope list change is required.

A previous attempt (#118) was closed unmerged and had no tests. This version matches the current invoice/quote handler + tool pattern and includes unit tests.

## Validation
- `npm test` — 37 passing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`