### PR TITLE
feat: add general ledger journal tools (list, get)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a Model Context Protocol (MCP) server implementation for Xero. It provid
 - Contact management
 - Chart of Accounts management
 - Invoice creation and management
+- General ledger journal listing
 - MCP protocol compliance
 
 ## Prerequisites
@@ -59,6 +60,8 @@ Custom connections require different scopes depending on when they were created.
 > **Note:** The MCP server automatically tries V1 scopes first and falls back to V2 if needed.
 > 
 > You can override these by setting the `XERO_SCOPES` environment variable to a space-separated list of scopes.
+>
+> `list-journals` and `get-journal` need `accounting.journals.read` on granular-scope apps (or `accounting.transactions` on older apps). Do not add `accounting.journals.read` to the default scope list unless Xero has approved it for your app — requesting it unapproved fails token exchange with `invalid_scope`.
 
 ##### Integrating the MCP server with Claude Desktop
 
@@ -143,6 +146,8 @@ payroll.timesheets
 - `list-invoices`: Retrieve a list of invoices
 - `list-items`: Retrieve a list of items
 - `list-manual-journals`: Retrieve a list of manual journals
+- `list-journals`: Retrieve posted general ledger journals
+- `get-journal`: Retrieve a general ledger journal by ID or number
 - `list-organisation-details`: Retrieve details about an organisation
 - `list-profit-and-loss`: Retrieve a profit and loss report
 - `list-quotes`: Retrieve a list of quotes

--- a/src/handlers/__tests__/mock-xero-client.ts
+++ b/src/handlers/__tests__/mock-xero-client.ts
@@ -1,0 +1,24 @@
+import { vi } from "vitest";
+
+export const mockAccountingApi = {
+  getJournals: vi.fn(),
+  getJournal: vi.fn(),
+  getJournalByNumber: vi.fn(),
+};
+
+export const mockXeroClient = {
+  authenticate: vi.fn().mockResolvedValue(undefined),
+  tenantId: "tenant-1",
+  accountingApi: mockAccountingApi,
+  getShortCode: vi.fn().mockResolvedValue("!abc"),
+};
+
+export function resetXeroClientMocks() {
+  mockXeroClient.authenticate.mockClear();
+  mockXeroClient.getShortCode.mockClear();
+  mockXeroClient.getShortCode.mockResolvedValue("!abc");
+  mockXeroClient.authenticate.mockResolvedValue(undefined);
+  for (const fn of Object.values(mockAccountingApi)) {
+    fn.mockReset();
+  }
+}

--- a/src/handlers/get-xero-journal.handler.test.ts
+++ b/src/handlers/get-xero-journal.handler.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { getXeroJournal } from "./get-xero-journal.handler.js";
+
+const journal = {
+  journalID: "j-1",
+  journalNumber: 101,
+  journalDate: "2026-08-01",
+  sourceType: "MANJOURNAL",
+  journalLines: [
+    { accountCode: "200", netAmount: 80, description: "Debit" },
+    { accountCode: "400", netAmount: -80, description: "Credit" },
+  ],
+};
+
+describe("getXeroJournal", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("retrieves a journal by ID", async () => {
+    mockAccountingApi.getJournal.mockResolvedValue({
+      body: { journals: [journal] },
+    });
+
+    const result = await getXeroJournal({ journalId: "j-1" });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result.journalID).toBe("j-1");
+    expect(mockAccountingApi.getJournal).toHaveBeenCalledWith(
+      "tenant-1",
+      "j-1",
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+    expect(mockAccountingApi.getJournalByNumber).not.toHaveBeenCalled();
+  });
+
+  it("retrieves a journal by number", async () => {
+    mockAccountingApi.getJournalByNumber.mockResolvedValue({
+      body: { journals: [journal] },
+    });
+
+    const result = await getXeroJournal({ journalNumber: 101 });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result.journalNumber).toBe(101);
+    expect(mockAccountingApi.getJournalByNumber).toHaveBeenCalledWith(
+      "tenant-1",
+      101,
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("prefers ID when both ID and number are provided", async () => {
+    mockAccountingApi.getJournal.mockResolvedValue({
+      body: { journals: [journal] },
+    });
+
+    await getXeroJournal({ journalId: "j-1", journalNumber: 101 });
+
+    expect(mockAccountingApi.getJournal).toHaveBeenCalledOnce();
+    expect(mockAccountingApi.getJournalByNumber).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when neither ID nor number is provided", async () => {
+    const result = await getXeroJournal({});
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Provide a journalId or journalNumber.",
+    });
+    expect(mockAccountingApi.getJournal).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when Xero returns no journal", async () => {
+    mockAccountingApi.getJournal.mockResolvedValue({
+      body: { journals: [] },
+    });
+
+    const result = await getXeroJournal({ journalId: "missing" });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Journal not found.",
+    });
+  });
+});

--- a/src/handlers/get-xero-journal.handler.ts
+++ b/src/handlers/get-xero-journal.handler.ts
@@ -1,0 +1,75 @@
+import { Journal } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface GetJournalParams {
+  journalId?: string;
+  journalNumber?: number;
+}
+
+async function fetchJournal(
+  params: GetJournalParams,
+): Promise<Journal | undefined> {
+  await xeroClient.authenticate();
+
+  if (params.journalId) {
+    const response = await xeroClient.accountingApi.getJournal(
+      xeroClient.tenantId,
+      params.journalId,
+      getClientHeaders(),
+    );
+    return response.body.journals?.[0];
+  }
+
+  if (params.journalNumber != null) {
+    const response = await xeroClient.accountingApi.getJournalByNumber(
+      xeroClient.tenantId,
+      params.journalNumber,
+      getClientHeaders(),
+    );
+    return response.body.journals?.[0];
+  }
+
+  return undefined;
+}
+
+/**
+ * Retrieve a single general ledger journal from Xero.
+ */
+export async function getXeroJournal(
+  params: GetJournalParams,
+): Promise<XeroClientResponse<Journal>> {
+  try {
+    if (!params.journalId && params.journalNumber == null) {
+      return {
+        result: null,
+        isError: true,
+        error: "Provide a journalId or journalNumber.",
+      };
+    }
+
+    const journal = await fetchJournal(params);
+
+    if (!journal) {
+      return {
+        result: null,
+        isError: true,
+        error: "Journal not found.",
+      };
+    }
+
+    return {
+      result: journal,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-journals.handler.test.ts
+++ b/src/handlers/list-xero-journals.handler.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { listXeroJournals } from "./list-xero-journals.handler.js";
+
+const journals = [
+  {
+    journalID: "j-1",
+    journalNumber: 101,
+    journalDate: "2026-08-01",
+    sourceType: "ACCREC",
+  },
+];
+
+describe("listXeroJournals", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("lists general ledger journals with no filters", async () => {
+    mockAccountingApi.getJournals.mockResolvedValue({
+      body: { journals },
+    });
+
+    const result = await listXeroJournals();
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toEqual(journals);
+    expect(mockXeroClient.authenticate).toHaveBeenCalledOnce();
+    expect(mockAccountingApi.getJournals).toHaveBeenCalledWith(
+      "tenant-1",
+      undefined,
+      undefined,
+      undefined,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+  });
+
+  it("forwards offset, paymentsOnly, and ifModifiedSince", async () => {
+    mockAccountingApi.getJournals.mockResolvedValue({
+      body: { journals },
+    });
+
+    await listXeroJournals({
+      offset: 100,
+      paymentsOnly: true,
+      ifModifiedSince: "2026-07-01T00:00:00.000Z",
+    });
+
+    const [, ifModifiedSince, offset, paymentsOnly] =
+      mockAccountingApi.getJournals.mock.calls[0];
+    expect(ifModifiedSince).toBeInstanceOf(Date);
+    expect((ifModifiedSince as Date).toISOString()).toBe(
+      "2026-07-01T00:00:00.000Z",
+    );
+    expect(offset).toBe(100);
+    expect(paymentsOnly).toBe(true);
+  });
+
+  it("returns an error for an invalid ifModifiedSince value", async () => {
+    const result = await listXeroJournals({
+      ifModifiedSince: "not-a-date",
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "ifModifiedSince must be a valid date.",
+    });
+    expect(mockAccountingApi.getJournals).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list when Xero omits journals", async () => {
+    mockAccountingApi.getJournals.mockResolvedValue({ body: {} });
+
+    const result = await listXeroJournals();
+
+    expect(result).toEqual({
+      result: [],
+      isError: false,
+      error: null,
+    });
+  });
+
+  it("returns a formatted error when the list call fails", async () => {
+    mockAccountingApi.getJournals.mockRejectedValue(
+      new Error("insufficient_scope"),
+    );
+
+    const result = await listXeroJournals();
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "insufficient_scope",
+    });
+  });
+});

--- a/src/handlers/list-xero-journals.handler.ts
+++ b/src/handlers/list-xero-journals.handler.ts
@@ -1,0 +1,73 @@
+import { Journal } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface ListJournalsParams {
+  offset?: number;
+  paymentsOnly?: boolean;
+  ifModifiedSince?: string;
+}
+
+function parseIfModifiedSince(
+  value: string | undefined,
+): Date | undefined | "invalid" {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "invalid";
+  }
+  return parsed;
+}
+
+async function getJournals(
+  params: ListJournalsParams,
+): Promise<Journal[]> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getJournals(
+    xeroClient.tenantId,
+    parseIfModifiedSince(params.ifModifiedSince) as Date | undefined,
+    params.offset,
+    params.paymentsOnly,
+    getClientHeaders(),
+  );
+
+  return response.body.journals ?? [];
+}
+
+/**
+ * List general ledger journals from Xero (GET /Journals).
+ * This is not the Manual Journals endpoint.
+ */
+export async function listXeroJournals(
+  params: ListJournalsParams = {},
+): Promise<XeroClientResponse<Journal[]>> {
+  try {
+    if (parseIfModifiedSince(params.ifModifiedSince) === "invalid") {
+      return {
+        result: null,
+        isError: true,
+        error: "ifModifiedSince must be a valid date.",
+      };
+    }
+
+    const journals = await getJournals(params);
+
+    return {
+      result: journals,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/helpers/__tests__/format-journal.test.ts
+++ b/src/helpers/__tests__/format-journal.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { formatJournal } from "../format-journal.js";
+
+describe("formatJournal", () => {
+  it("labels positive net amounts as debit and negative as credit", () => {
+    const text = formatJournal({
+      journalID: "j-1",
+      journalNumber: 44,
+      journalDate: "2026-08-01",
+      sourceType: "ACCREC" as never,
+      sourceID: "inv-1",
+      reference: "INV-100",
+      journalLines: [
+        {
+          accountCode: "200",
+          accountName: "Sales",
+          netAmount: 80,
+          description: "Invoice",
+        },
+        {
+          accountCode: "610",
+          accountName: "Accounts Receivable",
+          netAmount: -80,
+        },
+      ],
+    });
+
+    expect(text).toContain("Journal ID: j-1");
+    expect(text).toContain("Journal Number: 44");
+    expect(text).toContain("Source Type: ACCREC");
+    expect(text).toContain("Source ID: inv-1");
+    expect(text).toContain("Account: 200 Sales");
+    expect(text).toContain("Debit: 80");
+    expect(text).toContain("Credit: 80");
+    expect(text).toContain("Description: Invoice");
+  });
+
+  it("omits the lines section when none are present", () => {
+    const text = formatJournal({
+      journalID: "j-2",
+      journalNumber: 45,
+    });
+
+    expect(text).toContain("Journal ID: j-2");
+    expect(text).not.toContain("Lines:");
+  });
+});

--- a/src/helpers/__tests__/vitest-setup.ts
+++ b/src/helpers/__tests__/vitest-setup.ts
@@ -1,0 +1,2 @@
+process.env.XERO_CLIENT_ID ??= "test-client-id";
+process.env.XERO_CLIENT_SECRET ??= "test-client-secret";

--- a/src/helpers/format-journal.ts
+++ b/src/helpers/format-journal.ts
@@ -1,0 +1,40 @@
+import { Journal, JournalLine } from "xero-node";
+
+const formatJournalLine = (line: JournalLine): string => {
+  const net = line.netAmount ?? 0;
+  const debitCredit =
+    net >= 0 ? `Debit: ${net}` : `Credit: ${Math.abs(net)}`;
+  const account = [line.accountCode, line.accountName]
+    .filter(Boolean)
+    .join(" ");
+
+  return [
+    account ? `Account: ${account}` : null,
+    debitCredit,
+    line.taxAmount != null ? `Tax Amount: ${line.taxAmount}` : null,
+    line.description ? `Description: ${line.description}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+};
+
+export const formatJournal = (journal: Journal): string => {
+  return [
+    `Journal ID: ${journal.journalID}`,
+    journal.journalNumber != null
+      ? `Journal Number: ${journal.journalNumber}`
+      : null,
+    journal.journalDate ? `Date: ${journal.journalDate}` : null,
+    journal.createdDateUTC
+      ? `Created: ${journal.createdDateUTC}`
+      : null,
+    journal.reference ? `Reference: ${journal.reference}` : null,
+    journal.sourceType ? `Source Type: ${journal.sourceType}` : null,
+    journal.sourceID ? `Source ID: ${journal.sourceID}` : null,
+    journal.journalLines?.length
+      ? `Lines:\n${journal.journalLines.map(formatJournalLine).join("\n---\n")}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+};

--- a/src/tools/get/get-journal.tool.ts
+++ b/src/tools/get/get-journal.tool.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { getXeroJournal } from "../../handlers/get-xero-journal.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatJournal } from "../../helpers/format-journal.js";
+
+const GetJournalTool = CreateXeroTool(
+  "get-journal",
+  `Retrieve a single general ledger journal from Xero by ID or journal number.
+  Provide journalId or journalNumber. If both are provided, the ID is used.
+  This is a posted ledger journal, not a manual journal document — use list-manual-journals for those.
+  Requires the accounting.journals.read scope on granular-scope apps (or accounting.transactions on older apps).
+  Positive line net amounts are debits; negative are credits.`,
+  {
+    journalId: z
+      .string()
+      .optional()
+      .describe("The ID of the general ledger journal to retrieve."),
+    journalNumber: z
+      .number()
+      .optional()
+      .describe("The Xero journal number, used when the ID is not available."),
+  },
+  async ({ journalId, journalNumber }) => {
+    const response = await getXeroJournal({ journalId, journalNumber });
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error retrieving journal: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: formatJournal(response.result),
+        },
+      ],
+    };
+  },
+);
+
+export default GetJournalTool;

--- a/src/tools/get/index.ts
+++ b/src/tools/get/index.ts
@@ -1,5 +1,7 @@
+import GetJournalTool from "./get-journal.tool.js";
 import GetPayrollTimesheetTool from "./get-payroll-timesheet.tool.js";
 
 export const GetTools = [
+  GetJournalTool,
   GetPayrollTimesheetTool,
 ];

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -7,6 +7,7 @@ import ListContactsTool from "./list-contacts.tool.js";
 import ListCreditNotesTool from "./list-credit-notes.tool.js";
 import ListInvoicesTool from "./list-invoices.tool.js";
 import ListItemsTool from "./list-items.tool.js";
+import ListJournalsTool from "./list-journals.tool.js";
 import ListManualJournalsTool from "./list-manual-journals.tool.js";
 import ListOrganisationDetailsTool from "./list-organisation-details.tool.js";
 import ListPaymentsTool from "./list-payments.tool.js";
@@ -35,6 +36,7 @@ export const ListTools = [
   ListCreditNotesTool,
   ListInvoicesTool,
   ListItemsTool,
+  ListJournalsTool,
   ListManualJournalsTool,
   ListQuotesTool,
   ListTaxRatesTool,

--- a/src/tools/list/list-journals.tool.ts
+++ b/src/tools/list/list-journals.tool.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import { listXeroJournals } from "../../handlers/list-xero-journals.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatJournal } from "../../helpers/format-journal.js";
+
+const ListJournalsTool = CreateXeroTool(
+  "list-journals",
+  `List general ledger journals from Xero (GET /Journals).
+  These are the posted double-entry journals created by invoices, payments, manual journals, and other source transactions.
+  This is not list-manual-journals — use that tool for user-created draft/posted manual journals.
+  Xero returns journals in journal-number order, typically 100 at a time.
+  If 100 journals are returned, call this tool again with offset set to the last Journal Number.
+  Requires the accounting.journals.read scope on granular-scope apps (or accounting.transactions on older apps).
+  This endpoint can be premium-gated by Xero. Positive line net amounts are debits; negative are credits.`,
+  {
+    offset: z
+      .number()
+      .optional()
+      .describe(
+        "Return journals with a Journal Number greater than this value. Use the last Journal Number from the previous page.",
+      ),
+    ifModifiedSince: z
+      .string()
+      .optional()
+      .describe(
+        "Only return journals created or modified after this timestamp (ISO 8601 or YYYY-MM-DD).",
+      ),
+    paymentsOnly: z
+      .boolean()
+      .optional()
+      .describe(
+        "If true, return cash-basis payment journals only. Defaults to accrual journals.",
+      ),
+  },
+  async ({ offset, ifModifiedSince, paymentsOnly }) => {
+    const response = await listXeroJournals({
+      offset,
+      ifModifiedSince,
+      paymentsOnly,
+    });
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing journals: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const journals = response.result;
+    const lastJournalNumber = journals?.at(-1)?.journalNumber;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${journals?.length || 0} journals:${
+            journals?.length === 100 && lastJournalNumber != null
+              ? ` Xero may have more. Call list-journals again with offset ${lastJournalNumber}.`
+              : ""
+          }`,
+        },
+        ...(journals?.map((journal) => ({
+          type: "text" as const,
+          text: formatJournal(journal),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListJournalsTool;

--- a/src/tools/tool-factory.test.ts
+++ b/src/tools/tool-factory.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { GetTools } from "./get/index.js";
+import { ListTools } from "./list/index.js";
+
+describe("journal tools are registered", () => {
+  it("includes list-journals and get-journal", () => {
+    const names = [...ListTools, ...GetTools].map((tool) => tool().name);
+
+    expect(names).toEqual(
+      expect.arrayContaining(["list-journals", "get-journal"]),
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    setupFiles: ["src/helpers/__tests__/vitest-setup.ts"],
   },
 });
+


### PR DESCRIPTION
## Summary

Adds read tools for Xero **general ledger** journals (`GET /Journals`). This is the gap in #122 — distinct from the existing Manual Journals tools.

Closes #122.

### Tools
- `list-journals` — list posted ledger journals with `offset` (journal number), `ifModifiedSince`, and `paymentsOnly`
- `get-journal` — fetch one journal by ID or journal number

Line amounts are labelled debit (positive net) / credit (negative net) so period-end extracts do not have to guess the sign convention.

### Scopes
These tools need `accounting.journals.read` on granular-scope apps, or `accounting.transactions` on older apps. That scope is **not** added to the default Custom Connection list — requesting it without Xero approval fails token exchange with `invalid_scope`. The README and tool descriptions call this out. Xero also premium-gates `/Journals` on some plans.

## Validation
- `npm test` — 27 passing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`