### PR TITLE
feat: add payroll employee leave write tools (create, update, delete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ payroll.timesheets
 - `list-payroll-employees`: Retrieve a list of Payroll Employees
 - `list-report-balance-sheet`: Retrieve a balance sheet report
 - `list-payroll-employee-leave`: Retrieve a Payroll Employee's leave records
+- `create-payroll-employee-leave`: Create a Payroll Employee leave request (NZ)
+- `update-payroll-employee-leave`: Update a Payroll Employee leave request (NZ)
+- `delete-payroll-employee-leave`: Delete a Payroll Employee leave request (NZ)
 - `list-payroll-employee-leave-balances`: Retrieve a Payroll Employee's leave balances
 - `list-payroll-employee-leave-types`: Retrieve a list of Payroll leave types
 - `list-payroll-leave-periods`: Retrieve a list of a Payroll Employee's leave periods

--- a/src/handlers/__tests__/mock-xero-client.ts
+++ b/src/handlers/__tests__/mock-xero-client.ts
@@ -1,0 +1,22 @@
+import { vi } from "vitest";
+
+export const mockPayrollNZApi = {
+  createEmployeeLeave: vi.fn(),
+  updateEmployeeLeave: vi.fn(),
+  deleteEmployeeLeave: vi.fn(),
+  getEmployeeLeaves: vi.fn(),
+};
+
+export const mockXeroClient = {
+  authenticate: vi.fn().mockResolvedValue(undefined),
+  tenantId: "tenant-1",
+  payrollNZApi: mockPayrollNZApi,
+};
+
+export function resetXeroClientMocks() {
+  mockXeroClient.authenticate.mockClear();
+  mockXeroClient.authenticate.mockResolvedValue(undefined);
+  for (const fn of Object.values(mockPayrollNZApi)) {
+    fn.mockReset();
+  }
+}

--- a/src/handlers/create-xero-payroll-employee-leave.handler.test.ts
+++ b/src/handlers/create-xero-payroll-employee-leave.handler.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockPayrollNZApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { createXeroPayrollEmployeeLeave } from "./create-xero-payroll-employee-leave.handler.js";
+
+const createdLeave = {
+  leaveID: "leave-1",
+  leaveTypeID: "type-1",
+  description: "Annual leave",
+  startDate: "2026-09-01",
+  endDate: "2026-09-05",
+  periods: [
+    {
+      periodStartDate: "2026-09-01",
+      periodEndDate: "2026-09-05",
+      numberOfUnits: 40,
+      periodStatus: "Approved",
+    },
+  ],
+};
+
+const createParams = {
+  employeeId: "emp-1",
+  leaveTypeID: "type-1",
+  description: "Annual leave",
+  startDate: "2026-09-01",
+  endDate: "2026-09-05",
+};
+
+describe("createXeroPayrollEmployeeLeave", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("creates employee leave and returns the created record", async () => {
+    mockPayrollNZApi.createEmployeeLeave.mockResolvedValue({
+      body: { leave: createdLeave },
+    });
+
+    const result = await createXeroPayrollEmployeeLeave(createParams);
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toEqual(createdLeave);
+    expect(mockXeroClient.authenticate).toHaveBeenCalledOnce();
+    expect(mockPayrollNZApi.createEmployeeLeave).toHaveBeenCalledWith(
+      "tenant-1",
+      "emp-1",
+      {
+        leaveTypeID: "type-1",
+        description: "Annual leave",
+        startDate: "2026-09-01",
+        endDate: "2026-09-05",
+      },
+      undefined,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+  });
+
+  it("forwards optional leave periods so units can be overridden", async () => {
+    mockPayrollNZApi.createEmployeeLeave.mockResolvedValue({
+      body: { leave: createdLeave },
+    });
+
+    const periods = [
+      {
+        periodStartDate: "2026-09-01",
+        periodEndDate: "2026-09-05",
+        numberOfUnits: 32,
+      },
+    ];
+
+    await createXeroPayrollEmployeeLeave({
+      ...createParams,
+      periods,
+    });
+
+    const employeeLeave = mockPayrollNZApi.createEmployeeLeave.mock.calls[0][2];
+    expect(employeeLeave.periods).toEqual(periods);
+  });
+
+  it("returns an error when Xero omits the created leave", async () => {
+    mockPayrollNZApi.createEmployeeLeave.mockResolvedValue({ body: {} });
+
+    const result = await createXeroPayrollEmployeeLeave(createParams);
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Leave creation failed.",
+    });
+  });
+
+  it("returns a formatted error when the create call fails", async () => {
+    mockPayrollNZApi.createEmployeeLeave.mockRejectedValue(
+      new Error("leave setup is required"),
+    );
+
+    const result = await createXeroPayrollEmployeeLeave(createParams);
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "leave setup is required",
+    });
+  });
+});

--- a/src/handlers/create-xero-payroll-employee-leave.handler.ts
+++ b/src/handlers/create-xero-payroll-employee-leave.handler.ts
@@ -1,0 +1,65 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { EmployeeLeave, LeavePeriod } from "../types/payroll-nz-types.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface CreatePayrollEmployeeLeaveParams {
+  employeeId: string;
+  leaveTypeID: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  periods?: LeavePeriod[];
+}
+
+async function createEmployeeLeave(
+  params: CreatePayrollEmployeeLeaveParams,
+): Promise<EmployeeLeave | null> {
+  await xeroClient.authenticate();
+
+  const employeeLeave: EmployeeLeave = {
+    leaveTypeID: params.leaveTypeID,
+    description: params.description,
+    startDate: params.startDate,
+    endDate: params.endDate,
+    ...(params.periods ? { periods: params.periods } : {}),
+  };
+
+  const response = await xeroClient.payrollNZApi.createEmployeeLeave(
+    xeroClient.tenantId,
+    params.employeeId,
+    employeeLeave,
+    undefined,
+    getClientHeaders(),
+  );
+
+  return response.body.leave ?? null;
+}
+
+/**
+ * Create a payroll leave request for an employee in Xero (NZ Payroll).
+ */
+export async function createXeroPayrollEmployeeLeave(
+  params: CreatePayrollEmployeeLeaveParams,
+): Promise<XeroClientResponse<EmployeeLeave>> {
+  try {
+    const createdLeave = await createEmployeeLeave(params);
+
+    if (!createdLeave) {
+      throw new Error("Leave creation failed.");
+    }
+
+    return {
+      result: createdLeave,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/delete-xero-payroll-employee-leave.handler.test.ts
+++ b/src/handlers/delete-xero-payroll-employee-leave.handler.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockPayrollNZApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { deleteXeroPayrollEmployeeLeave } from "./delete-xero-payroll-employee-leave.handler.js";
+
+describe("deleteXeroPayrollEmployeeLeave", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("deletes employee leave by employee and leave ID", async () => {
+    mockPayrollNZApi.deleteEmployeeLeave.mockResolvedValue({
+      body: {},
+    });
+
+    const result = await deleteXeroPayrollEmployeeLeave({
+      employeeId: "emp-1",
+      leaveId: "leave-1",
+    });
+
+    expect(result).toEqual({
+      result: true,
+      isError: false,
+      error: null,
+    });
+    expect(mockXeroClient.authenticate).toHaveBeenCalledOnce();
+    expect(mockPayrollNZApi.deleteEmployeeLeave).toHaveBeenCalledWith(
+      "tenant-1",
+      "emp-1",
+      "leave-1",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+  });
+
+  it("returns a formatted error when the delete call fails", async () => {
+    mockPayrollNZApi.deleteEmployeeLeave.mockRejectedValue(
+      new Error("cannot delete processed leave"),
+    );
+
+    const result = await deleteXeroPayrollEmployeeLeave({
+      employeeId: "emp-1",
+      leaveId: "leave-1",
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "cannot delete processed leave",
+    });
+  });
+});

--- a/src/handlers/delete-xero-payroll-employee-leave.handler.ts
+++ b/src/handlers/delete-xero-payroll-employee-leave.handler.ts
@@ -1,0 +1,45 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface DeletePayrollEmployeeLeaveParams {
+  employeeId: string;
+  leaveId: string;
+}
+
+async function deleteEmployeeLeave(
+  params: DeletePayrollEmployeeLeaveParams,
+): Promise<void> {
+  await xeroClient.authenticate();
+
+  await xeroClient.payrollNZApi.deleteEmployeeLeave(
+    xeroClient.tenantId,
+    params.employeeId,
+    params.leaveId,
+    getClientHeaders(),
+  );
+}
+
+/**
+ * Delete a payroll leave request for an employee in Xero (NZ Payroll).
+ */
+export async function deleteXeroPayrollEmployeeLeave(
+  params: DeletePayrollEmployeeLeaveParams,
+): Promise<XeroClientResponse<boolean>> {
+  try {
+    await deleteEmployeeLeave(params);
+
+    return {
+      result: true,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/update-xero-payroll-employee-leave.handler.test.ts
+++ b/src/handlers/update-xero-payroll-employee-leave.handler.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockPayrollNZApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { updateXeroPayrollEmployeeLeave } from "./update-xero-payroll-employee-leave.handler.js";
+
+const existingLeave = {
+  leaveID: "leave-1",
+  leaveTypeID: "type-1",
+  description: "Annual leave",
+  startDate: "2026-09-01",
+  endDate: "2026-09-05",
+  periods: [
+    {
+      periodStartDate: "2026-09-01",
+      periodEndDate: "2026-09-05",
+      numberOfUnits: 40,
+    },
+  ],
+};
+
+const updatedLeave = {
+  ...existingLeave,
+  endDate: "2026-09-08",
+};
+
+describe("updateXeroPayrollEmployeeLeave", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+    mockPayrollNZApi.getEmployeeLeaves.mockResolvedValue({
+      body: { leave: [existingLeave] },
+    });
+  });
+
+  it("merges partial fields onto the existing leave before PUT", async () => {
+    mockPayrollNZApi.updateEmployeeLeave.mockResolvedValue({
+      body: { leave: updatedLeave },
+    });
+
+    const result = await updateXeroPayrollEmployeeLeave({
+      employeeId: "emp-1",
+      leaveId: "leave-1",
+      endDate: "2026-09-08",
+    });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toEqual(updatedLeave);
+    expect(mockPayrollNZApi.getEmployeeLeaves).toHaveBeenCalledWith(
+      "tenant-1",
+      "emp-1",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+    expect(mockPayrollNZApi.updateEmployeeLeave).toHaveBeenCalledWith(
+      "tenant-1",
+      "emp-1",
+      "leave-1",
+      {
+        leaveTypeID: "type-1",
+        description: "Annual leave",
+        startDate: "2026-09-01",
+        endDate: "2026-09-08",
+      },
+      undefined,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+  });
+
+  it("forwards periods when they are provided", async () => {
+    mockPayrollNZApi.updateEmployeeLeave.mockResolvedValue({
+      body: { leave: updatedLeave },
+    });
+
+    const periods = [
+      {
+        periodStartDate: "2026-09-01",
+        periodEndDate: "2026-09-08",
+        numberOfUnits: 48,
+      },
+    ];
+
+    await updateXeroPayrollEmployeeLeave({
+      employeeId: "emp-1",
+      leaveId: "leave-1",
+      periods,
+    });
+
+    const employeeLeave = mockPayrollNZApi.updateEmployeeLeave.mock.calls[0][3];
+    expect(employeeLeave.periods).toEqual(periods);
+  });
+
+  it("returns an error when the leave is not in the employee's records", async () => {
+    const result = await updateXeroPayrollEmployeeLeave({
+      employeeId: "emp-1",
+      leaveId: "missing",
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Leave missing was not found for employee emp-1.",
+    });
+    expect(mockPayrollNZApi.updateEmployeeLeave).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when Xero omits the updated leave", async () => {
+    mockPayrollNZApi.updateEmployeeLeave.mockResolvedValue({ body: {} });
+
+    const result = await updateXeroPayrollEmployeeLeave({
+      employeeId: "emp-1",
+      leaveId: "leave-1",
+      description: "Updated description",
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Leave update failed.",
+    });
+  });
+
+  it("returns a formatted error when the update call fails", async () => {
+    mockPayrollNZApi.updateEmployeeLeave.mockRejectedValue(
+      new Error("cannot update completed leave"),
+    );
+
+    const result = await updateXeroPayrollEmployeeLeave({
+      employeeId: "emp-1",
+      leaveId: "leave-1",
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "cannot update completed leave",
+    });
+  });
+});

--- a/src/handlers/update-xero-payroll-employee-leave.handler.ts
+++ b/src/handlers/update-xero-payroll-employee-leave.handler.ts
@@ -1,0 +1,91 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { EmployeeLeave, LeavePeriod } from "../types/payroll-nz-types.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface UpdatePayrollEmployeeLeaveParams {
+  employeeId: string;
+  leaveId: string;
+  leaveTypeID?: string;
+  description?: string;
+  startDate?: string;
+  endDate?: string;
+  periods?: LeavePeriod[];
+}
+
+async function getExistingLeave(
+  employeeId: string,
+  leaveId: string,
+): Promise<EmployeeLeave> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.payrollNZApi.getEmployeeLeaves(
+    xeroClient.tenantId,
+    employeeId,
+    getClientHeaders(),
+  );
+
+  const existing = response.body.leave?.find(
+    (leave) => leave.leaveID === leaveId,
+  );
+
+  if (!existing) {
+    throw new Error(`Leave ${leaveId} was not found for employee ${employeeId}.`);
+  }
+
+  return existing;
+}
+
+async function updateEmployeeLeave(
+  params: UpdatePayrollEmployeeLeaveParams,
+  existing: EmployeeLeave,
+): Promise<EmployeeLeave | null> {
+  const employeeLeave: EmployeeLeave = {
+    leaveTypeID: params.leaveTypeID ?? existing.leaveTypeID,
+    description: params.description ?? existing.description,
+    startDate: params.startDate ?? existing.startDate,
+    endDate: params.endDate ?? existing.endDate,
+    ...(params.periods ? { periods: params.periods } : {}),
+  };
+
+  const response = await xeroClient.payrollNZApi.updateEmployeeLeave(
+    xeroClient.tenantId,
+    params.employeeId,
+    params.leaveId,
+    employeeLeave,
+    undefined,
+    getClientHeaders(),
+  );
+
+  return response.body.leave ?? null;
+}
+
+/**
+ * Update a payroll leave request for an employee in Xero (NZ Payroll).
+ * Unspecified fields are copied from the existing leave so PUT can send a full body.
+ */
+export async function updateXeroPayrollEmployeeLeave(
+  params: UpdatePayrollEmployeeLeaveParams,
+): Promise<XeroClientResponse<EmployeeLeave>> {
+  try {
+    const existing = await getExistingLeave(params.employeeId, params.leaveId);
+    const updatedLeave = await updateEmployeeLeave(params, existing);
+
+    if (!updatedLeave) {
+      throw new Error("Leave update failed.");
+    }
+
+    return {
+      result: updatedLeave,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/helpers/__tests__/vitest-setup.ts
+++ b/src/helpers/__tests__/vitest-setup.ts
@@ -1,0 +1,2 @@
+process.env.XERO_CLIENT_ID ??= "test-client-id";
+process.env.XERO_CLIENT_SECRET ??= "test-client-secret";

--- a/src/tools/create/create-payroll-employee-leave.tool.ts
+++ b/src/tools/create/create-payroll-employee-leave.tool.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+
+import { createXeroPayrollEmployeeLeave } from "../../handlers/create-xero-payroll-employee-leave.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const leavePeriodSchema = z.object({
+  periodStartDate: z
+    .string()
+    .describe("Pay period start date (YYYY-MM-DD).")
+    .optional(),
+  periodEndDate: z
+    .string()
+    .describe("Pay period end date (YYYY-MM-DD).")
+    .optional(),
+  numberOfUnits: z
+    .number()
+    .describe("Units to take in this period. Overrides Xero's automatic calculation.")
+    .optional(),
+  numberOfUnitsTaken: z
+    .number()
+    .describe("Units already taken in this period.")
+    .optional(),
+});
+
+const CreatePayrollEmployeeLeaveTool = CreateXeroTool(
+  "create-payroll-employee-leave",
+  `Create a leave request for an employee in Xero Payroll (NZ).
+The employee must already have leave setup. Get leaveTypeID from list-payroll-employee-leave-types or list-payroll-leave-types.
+Xero calculates the number of units automatically unless you pass periods with numberOfUnits.
+This uses the NZ Payroll API (same as list-payroll-employee-leave), not Australian leave applications.`,
+  {
+    employeeId: z
+      .string()
+      .describe("The Xero employee ID. Can be obtained from list-payroll-employees."),
+    leaveTypeID: z
+      .string()
+      .describe("The leave type ID. Can be obtained from list-payroll-employee-leave-types or list-payroll-leave-types."),
+    description: z
+      .string()
+      .max(50)
+      .describe("Description of the leave request (max 50 characters)."),
+    startDate: z.string().describe("Start date of the leave (YYYY-MM-DD)."),
+    endDate: z.string().describe("End date of the leave (YYYY-MM-DD)."),
+    periods: z
+      .array(leavePeriodSchema)
+      .optional()
+      .describe(
+        "Optional pay-period breakdown. Provide this only when you need to override the automatically calculated number of units.",
+      ),
+  },
+  async ({ employeeId, leaveTypeID, description, startDate, endDate, periods }) => {
+    const response = await createXeroPayrollEmployeeLeave({
+      employeeId,
+      leaveTypeID,
+      description,
+      startDate,
+      endDate,
+      periods,
+    });
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error creating employee leave: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const leave = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Employee leave created successfully:",
+            `Leave ID: ${leave.leaveID}`,
+            `Leave Type ID: ${leave.leaveTypeID}`,
+            `Description: ${leave.description}`,
+            `Start Date: ${leave.startDate}`,
+            `End Date: ${leave.endDate}`,
+            leave.periods?.length
+              ? `Periods: ${leave.periods.length}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default CreatePayrollEmployeeLeaveTool;

--- a/src/tools/create/index.ts
+++ b/src/tools/create/index.ts
@@ -5,6 +5,7 @@ import CreateInvoiceTool from "./create-invoice.tool.js";
 import CreateItemTool from "./create-item.tool.js";
 import CreateManualJournalTool from "./create-manual-journal.tool.js";
 import CreatePaymentTool from "./create-payment.tool.js";
+import CreatePayrollEmployeeLeaveTool from "./create-payroll-employee-leave.tool.js";
 import CreatePayrollTimesheetTool from "./create-payroll-timesheet.tool.js";
 import CreateQuoteTool from "./create-quote.tool.js";
 import CreateTrackingCategoryTool from "./create-tracking-category.tool.js";
@@ -20,6 +21,7 @@ export const CreateTools = [
   CreateItemTool,
   CreateBankTransactionTool,
   CreatePayrollTimesheetTool,
+  CreatePayrollEmployeeLeaveTool,
   CreateTrackingCategoryTool,
   CreateTrackingOptionsTool
 ];

--- a/src/tools/delete/delete-payroll-employee-leave.tool.ts
+++ b/src/tools/delete/delete-payroll-employee-leave.tool.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+import { deleteXeroPayrollEmployeeLeave } from "../../handlers/delete-xero-payroll-employee-leave.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const DeletePayrollEmployeeLeaveTool = CreateXeroTool(
+  "delete-payroll-employee-leave",
+  `Delete a leave request for an employee in Xero Payroll (NZ).
+Get leaveId from list-payroll-employee-leave. Completed or processed leave often cannot be deleted.
+This uses the NZ Payroll API (same as list-payroll-employee-leave), not Australian leave applications.`,
+  {
+    employeeId: z
+      .string()
+      .describe("The Xero employee ID. Can be obtained from list-payroll-employees."),
+    leaveId: z
+      .string()
+      .describe("The leave ID to delete. Can be obtained from list-payroll-employee-leave."),
+  },
+  async ({ employeeId, leaveId }) => {
+    const response = await deleteXeroPayrollEmployeeLeave({
+      employeeId,
+      leaveId,
+    });
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error deleting employee leave: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Successfully deleted leave ${leaveId} for employee ${employeeId}.`,
+        },
+      ],
+    };
+  },
+);
+
+export default DeletePayrollEmployeeLeaveTool;

--- a/src/tools/delete/index.ts
+++ b/src/tools/delete/index.ts
@@ -1,5 +1,7 @@
+import DeletePayrollEmployeeLeaveTool from "./delete-payroll-employee-leave.tool.js";
 import DeletePayrollTimesheetTool from "./delete-payroll-timesheet.tool.js";
 
 export const DeleteTools = [
-  DeletePayrollTimesheetTool
+  DeletePayrollTimesheetTool,
+  DeletePayrollEmployeeLeaveTool,
 ];

--- a/src/tools/tool-factory.test.ts
+++ b/src/tools/tool-factory.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { CreateTools } from "./create/index.js";
+import { DeleteTools } from "./delete/index.js";
+import { UpdateTools } from "./update/index.js";
+
+describe("payroll employee leave write tools are registered", () => {
+  it("includes create, update, and delete leave tools", () => {
+    const names = [...CreateTools, ...UpdateTools, ...DeleteTools].map(
+      (tool) => tool().name,
+    );
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "create-payroll-employee-leave",
+        "update-payroll-employee-leave",
+        "delete-payroll-employee-leave",
+      ]),
+    );
+  });
+});

--- a/src/tools/update/index.ts
+++ b/src/tools/update/index.ts
@@ -9,6 +9,7 @@ import AddTimesheetLineTool from "./update-payroll-timesheet-add-line.tool.js";
 import UpdatePayrollTimesheetLineTool
   from "./update-payroll-timesheet-update-line.tool.js";
 import UpdateManualJournalTool from "./update-manual-journal-tool.js";
+import UpdatePayrollEmployeeLeaveTool from "./update-payroll-employee-leave.tool.js";
 import UpdateQuoteTool from "./update-quote.tool.js";
 import UpdateTrackingCategoryTool from "./update-tracking-category.tool.js";
 import UpdateTrackingOptionsTool from "./update-tracking-options.tool.js";
@@ -25,6 +26,7 @@ export const UpdateTools = [
   AddTimesheetLineTool,
   UpdatePayrollTimesheetLineTool,
   RevertPayrollTimesheetTool,
+  UpdatePayrollEmployeeLeaveTool,
   UpdateTrackingCategoryTool,
   UpdateTrackingOptionsTool
 ];

--- a/src/tools/update/update-payroll-employee-leave.tool.ts
+++ b/src/tools/update/update-payroll-employee-leave.tool.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+
+import { updateXeroPayrollEmployeeLeave } from "../../handlers/update-xero-payroll-employee-leave.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const leavePeriodSchema = z.object({
+  periodStartDate: z
+    .string()
+    .describe("Pay period start date (YYYY-MM-DD).")
+    .optional(),
+  periodEndDate: z
+    .string()
+    .describe("Pay period end date (YYYY-MM-DD).")
+    .optional(),
+  numberOfUnits: z
+    .number()
+    .describe("Units to take in this period. Overrides Xero's automatic calculation.")
+    .optional(),
+  numberOfUnitsTaken: z
+    .number()
+    .describe("Units already taken in this period.")
+    .optional(),
+});
+
+const UpdatePayrollEmployeeLeaveTool = CreateXeroTool(
+  "update-payroll-employee-leave",
+  `Update an existing leave request for an employee in Xero Payroll (NZ).
+Unspecified fields are kept from the current leave record. Get leaveId from list-payroll-employee-leave.
+Omit periods unless you need to override the automatically calculated number of units.
+This uses the NZ Payroll API (same as list-payroll-employee-leave), not Australian leave applications.`,
+  {
+    employeeId: z
+      .string()
+      .describe("The Xero employee ID. Can be obtained from list-payroll-employees."),
+    leaveId: z
+      .string()
+      .describe("The leave ID to update. Can be obtained from list-payroll-employee-leave."),
+    leaveTypeID: z
+      .string()
+      .optional()
+      .describe("Replacement leave type ID. Can be obtained from list-payroll-employee-leave-types."),
+    description: z
+      .string()
+      .max(50)
+      .optional()
+      .describe("Replacement description (max 50 characters)."),
+    startDate: z
+      .string()
+      .optional()
+      .describe("Replacement start date (YYYY-MM-DD)."),
+    endDate: z
+      .string()
+      .optional()
+      .describe("Replacement end date (YYYY-MM-DD)."),
+    periods: z
+      .array(leavePeriodSchema)
+      .optional()
+      .describe(
+        "Optional pay-period breakdown. Provide this only when you need to override the automatically calculated number of units.",
+      ),
+  },
+  async ({
+    employeeId,
+    leaveId,
+    leaveTypeID,
+    description,
+    startDate,
+    endDate,
+    periods,
+  }) => {
+    const response = await updateXeroPayrollEmployeeLeave({
+      employeeId,
+      leaveId,
+      leaveTypeID,
+      description,
+      startDate,
+      endDate,
+      periods,
+    });
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error updating employee leave: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const leave = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Employee leave updated successfully:",
+            `Leave ID: ${leave.leaveID}`,
+            `Leave Type ID: ${leave.leaveTypeID}`,
+            `Description: ${leave.description}`,
+            `Start Date: ${leave.startDate}`,
+            `End Date: ${leave.endDate}`,
+            leave.periods?.length
+              ? `Periods: ${leave.periods.length}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default UpdatePayrollEmployeeLeaveTool;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    setupFiles: ["src/helpers/__tests__/vitest-setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Adds write tools for NZ Payroll leave requests. Read already exists (`list-payroll-employee-leave`); this covers the write side of #72.

### Tools
- `create-payroll-employee-leave` — create a leave request (`leaveTypeID`, description, start/end dates)
- `update-payroll-employee-leave` — update an existing request; unspecified fields are copied from the current record so PUT can send a full body
- `delete-payroll-employee-leave` — delete a leave request (processed/completed leave often cannot be deleted)

Xero calculates leave units automatically unless `periods` with `numberOfUnits` are supplied.

This uses `payrollNZApi`, the same client as the existing leave list tools. It does **not** add Australian `LeaveApplications` (that is a different API; see #130 / #171). UK payroll has a similar leave surface, but this server’s other leave tools are NZ-only today.

Scope is unchanged: leave write is covered by `payroll.employees`, which is already in the default Custom Connection lists.

## Validation
- `npm test` — 26 passing
- `npx tsc --noEmit`
- `npm run lint`