### PR TITLE
feat: add repeating invoice tools (list, get, create, update, delete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ payroll.timesheets
 - `list-organisation-details`: Retrieve details about an organisation
 - `list-profit-and-loss`: Retrieve a profit and loss report
 - `list-quotes`: Retrieve a list of quotes
+- `list-repeating-invoices`: Retrieve repeating invoice templates
 - `list-tax-rates`: Retrieve a list of tax rates
 - `list-payments`: Retrieve a list of payments
 - `list-trial-balance`: Retrieve a trial balance report
@@ -170,6 +171,7 @@ payroll.timesheets
 - `create-manual-journal`: Create a new manual journal
 - `create-payment`: Create a new payment
 - `create-quote`: Create a new quote
+- `create-repeating-invoice`: Create a new repeating invoice template
 - `create-payroll-timesheet`: Create a new Payroll Timesheet
 - `create-tracking-category`: Create a new tracking category
 - `create-tracking-option`: Create a new tracking option
@@ -179,6 +181,7 @@ payroll.timesheets
 - `update-item`: Update an existing item
 - `update-manual-journal`: Update an existing manual journal
 - `update-quote`: Update an existing draft quote
+- `update-repeating-invoice`: Update an existing repeating invoice template
 - `update-credit-note`: Update an existing draft credit note
 - `update-tracking-category`: Update an existing tracking category
 - `update-tracking-options`: Update tracking options
@@ -187,7 +190,9 @@ payroll.timesheets
 - `revert-payroll-timesheet`: Revert an approved Payroll Timesheet
 - `add-payroll-timesheet-line`: Add new line on an existing Payroll Timesheet
 - `delete-payroll-timesheet`: Delete an existing Payroll Timesheet
+- `delete-repeating-invoice`: Delete an existing repeating invoice template
 - `get-payroll-timesheet`: Retrieve an existing Payroll Timesheet
+- `get-repeating-invoice`: Retrieve a repeating invoice template by ID
 
 For detailed API documentation, please refer to the [MCP Protocol Specification](https://modelcontextprotocol.io/).
 

--- a/src/handlers/__tests__/mock-xero-client.ts
+++ b/src/handlers/__tests__/mock-xero-client.ts
@@ -1,0 +1,25 @@
+import { vi } from "vitest";
+
+export const mockAccountingApi = {
+  getRepeatingInvoices: vi.fn(),
+  getRepeatingInvoice: vi.fn(),
+  createRepeatingInvoices: vi.fn(),
+  updateRepeatingInvoice: vi.fn(),
+};
+
+export const mockXeroClient = {
+  authenticate: vi.fn().mockResolvedValue(undefined),
+  tenantId: "tenant-1",
+  accountingApi: mockAccountingApi,
+  getShortCode: vi.fn().mockResolvedValue("!abc"),
+};
+
+export function resetXeroClientMocks() {
+  mockXeroClient.authenticate.mockClear();
+  mockXeroClient.getShortCode.mockClear();
+  mockXeroClient.getShortCode.mockResolvedValue("!abc");
+  mockXeroClient.authenticate.mockResolvedValue(undefined);
+  for (const fn of Object.values(mockAccountingApi)) {
+    fn.mockReset();
+  }
+}

--- a/src/handlers/create-xero-repeating-invoice.handler.test.ts
+++ b/src/handlers/create-xero-repeating-invoice.handler.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { createXeroRepeatingInvoice } from "./create-xero-repeating-invoice.handler.js";
+
+const lineItems = [
+  {
+    description: "Monthly retainer",
+    quantity: 1,
+    unitAmount: 500,
+    accountCode: "200",
+    taxType: "OUTPUT2",
+  },
+];
+
+const schedule = {
+  period: 1,
+  unit: "MONTHLY" as const,
+  dueDate: 10,
+  dueDateType: "OFFOLLOWINGMONTH" as const,
+  startDate: "2026-09-01",
+};
+
+const createdRepeatingInvoice = {
+  repeatingInvoiceID: "ri-1",
+  status: "DRAFT",
+  total: 500,
+  contact: { contactID: "contact-1", name: "Northwind" },
+};
+
+describe("createXeroRepeatingInvoice", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("creates a draft repeating invoice and returns it", async () => {
+    mockAccountingApi.createRepeatingInvoices.mockResolvedValue({
+      body: { repeatingInvoices: [createdRepeatingInvoice] },
+    });
+
+    const result = await createXeroRepeatingInvoice({
+      contactId: "contact-1",
+      lineItems,
+      schedule,
+    });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result.repeatingInvoiceID).toBe("ri-1");
+    expect(mockXeroClient.authenticate).toHaveBeenCalledOnce();
+    expect(mockAccountingApi.createRepeatingInvoices).toHaveBeenCalledWith(
+      "tenant-1",
+      {
+        repeatingInvoices: [
+          expect.objectContaining({
+            contact: { contactID: "contact-1" },
+            lineItems,
+            type: "ACCREC",
+            status: "DRAFT",
+            lineAmountTypes: "Exclusive",
+            schedule: expect.objectContaining({
+              period: 1,
+              unit: "MONTHLY",
+              dueDate: 10,
+              dueDateType: "OFFOLLOWINGMONTH",
+              startDate: "2026-09-01",
+            }),
+          }),
+        ],
+      },
+      true,
+      undefined,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+  });
+
+  it("passes optional bill type, authorised status, and reference through to Xero", async () => {
+    mockAccountingApi.createRepeatingInvoices.mockResolvedValue({
+      body: { repeatingInvoices: [createdRepeatingInvoice] },
+    });
+
+    await createXeroRepeatingInvoice({
+      contactId: "contact-1",
+      lineItems,
+      schedule: { ...schedule, endDate: "2026-12-01", unit: "WEEKLY" },
+      type: "ACCPAY",
+      status: "AUTHORISED",
+      reference: "RETAINER",
+      lineAmountTypes: "Inclusive",
+    });
+
+    const payload = mockAccountingApi.createRepeatingInvoices.mock.calls[0][1];
+    expect(payload.repeatingInvoices[0]).toMatchObject({
+      type: "ACCPAY",
+      status: "AUTHORISED",
+      reference: "RETAINER",
+      lineAmountTypes: "Inclusive",
+      schedule: expect.objectContaining({
+        unit: "WEEKLY",
+        endDate: "2026-12-01",
+      }),
+    });
+  });
+
+  it("returns a formatted error when Xero rejects the create", async () => {
+    mockAccountingApi.createRepeatingInvoices.mockRejectedValue(
+      new Error("Contact is required"),
+    );
+
+    const result = await createXeroRepeatingInvoice({
+      contactId: "missing",
+      lineItems,
+      schedule,
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Contact is required",
+    });
+  });
+
+  it("returns an error when Xero returns no repeating invoice", async () => {
+    mockAccountingApi.createRepeatingInvoices.mockResolvedValue({
+      body: { repeatingInvoices: [] },
+    });
+
+    const result = await createXeroRepeatingInvoice({
+      contactId: "contact-1",
+      lineItems,
+      schedule,
+    });
+
+    expect(result.isError).toBe(true);
+    if (!result.isError) return;
+    expect(result.error).toBe("Repeating invoice creation failed.");
+  });
+});

--- a/src/handlers/create-xero-repeating-invoice.handler.ts
+++ b/src/handlers/create-xero-repeating-invoice.handler.ts
@@ -1,0 +1,113 @@
+import { LineAmountTypes, RepeatingInvoice, Schedule } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import {
+  RepeatingInvoiceLineAmountTypes,
+  RepeatingInvoiceLineItem,
+  RepeatingInvoiceScheduleInput,
+  RepeatingInvoiceStatus,
+  RepeatingInvoiceType,
+} from "../types/repeating-invoice.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface CreateRepeatingInvoiceParams {
+  contactId: string;
+  lineItems: RepeatingInvoiceLineItem[];
+  schedule: RepeatingInvoiceScheduleInput;
+  type?: RepeatingInvoiceType;
+  reference?: string;
+  status?: Exclude<RepeatingInvoiceStatus, "DELETED">;
+  lineAmountTypes?: RepeatingInvoiceLineAmountTypes;
+}
+
+function mapLineAmountTypes(
+  lineAmountTypes?: RepeatingInvoiceLineAmountTypes,
+): LineAmountTypes {
+  if (lineAmountTypes === "Inclusive") {
+    return LineAmountTypes.Inclusive;
+  }
+  if (lineAmountTypes === "NoTax") {
+    return LineAmountTypes.NoTax;
+  }
+  return LineAmountTypes.Exclusive;
+}
+
+function mapDueDateType(
+  dueDateType: RepeatingInvoiceScheduleInput["dueDateType"],
+): Schedule.DueDateTypeEnum {
+  return Schedule.DueDateTypeEnum[dueDateType];
+}
+
+async function createRepeatingInvoice(
+  params: CreateRepeatingInvoiceParams,
+): Promise<RepeatingInvoice | undefined> {
+  await xeroClient.authenticate();
+
+  const repeatingInvoice: RepeatingInvoice = {
+    type:
+      params.type === "ACCPAY"
+        ? RepeatingInvoice.TypeEnum.ACCPAY
+        : RepeatingInvoice.TypeEnum.ACCREC,
+    contact: {
+      contactID: params.contactId,
+    },
+    lineItems: params.lineItems,
+    schedule: {
+      period: params.schedule.period,
+      unit:
+        params.schedule.unit === "WEEKLY"
+          ? Schedule.UnitEnum.WEEKLY
+          : Schedule.UnitEnum.MONTHLY,
+      dueDate: params.schedule.dueDate,
+      dueDateType: mapDueDateType(params.schedule.dueDateType),
+      startDate: params.schedule.startDate,
+      endDate: params.schedule.endDate,
+    },
+    reference: params.reference,
+    status:
+      params.status === "AUTHORISED"
+        ? RepeatingInvoice.StatusEnum.AUTHORISED
+        : RepeatingInvoice.StatusEnum.DRAFT,
+    lineAmountTypes: mapLineAmountTypes(params.lineAmountTypes),
+  };
+
+  const response = await xeroClient.accountingApi.createRepeatingInvoices(
+    xeroClient.tenantId,
+    {
+      repeatingInvoices: [repeatingInvoice],
+    },
+    true,
+    undefined,
+    getClientHeaders(),
+  );
+
+  return response.body.repeatingInvoices?.[0];
+}
+
+/**
+ * Create a new repeating invoice template in Xero
+ */
+export async function createXeroRepeatingInvoice(
+  params: CreateRepeatingInvoiceParams,
+): Promise<XeroClientResponse<RepeatingInvoice>> {
+  try {
+    const created = await createRepeatingInvoice(params);
+
+    if (!created) {
+      throw new Error("Repeating invoice creation failed.");
+    }
+
+    return {
+      result: created,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/delete-xero-repeating-invoice.handler.test.ts
+++ b/src/handlers/delete-xero-repeating-invoice.handler.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { deleteXeroRepeatingInvoice } from "./delete-xero-repeating-invoice.handler.js";
+
+const existing = {
+  repeatingInvoiceID: "ri-1",
+  status: "AUTHORISED",
+};
+
+describe("deleteXeroRepeatingInvoice", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("deletes a repeating invoice by setting status DELETED", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [existing] },
+    });
+    mockAccountingApi.updateRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [{ ...existing, status: "DELETED" }] },
+    });
+
+    const result = await deleteXeroRepeatingInvoice("ri-1");
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result.status).toBe("DELETED");
+    expect(mockAccountingApi.updateRepeatingInvoice).toHaveBeenCalledWith(
+      "tenant-1",
+      "ri-1",
+      {
+        repeatingInvoices: [{ status: "DELETED" }],
+      },
+      undefined,
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("rejects an already deleted repeating invoice", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [{ ...existing, status: "DELETED" }] },
+    });
+
+    const result = await deleteXeroRepeatingInvoice("ri-1");
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Repeating invoice is already deleted.",
+    });
+    expect(mockAccountingApi.updateRepeatingInvoice).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the repeating invoice cannot be loaded", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [] },
+    });
+
+    const result = await deleteXeroRepeatingInvoice("missing");
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Repeating invoice not found.",
+    });
+  });
+});

--- a/src/handlers/delete-xero-repeating-invoice.handler.ts
+++ b/src/handlers/delete-xero-repeating-invoice.handler.ts
@@ -1,0 +1,84 @@
+import { RepeatingInvoice } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function getRepeatingInvoice(
+  repeatingInvoiceId: string,
+): Promise<RepeatingInvoice | undefined> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getRepeatingInvoice(
+    xeroClient.tenantId,
+    repeatingInvoiceId,
+    getClientHeaders(),
+  );
+
+  return response.body.repeatingInvoices?.[0];
+}
+
+async function deleteRepeatingInvoice(
+  repeatingInvoiceId: string,
+): Promise<RepeatingInvoice | undefined> {
+  const response = await xeroClient.accountingApi.updateRepeatingInvoice(
+    xeroClient.tenantId,
+    repeatingInvoiceId,
+    {
+      repeatingInvoices: [
+        {
+          status: RepeatingInvoice.StatusEnum.DELETED,
+        },
+      ],
+    },
+    undefined,
+    getClientHeaders(),
+  );
+
+  return response.body.repeatingInvoices?.[0];
+}
+
+/**
+ * Delete a repeating invoice template by setting its status to DELETED
+ */
+export async function deleteXeroRepeatingInvoice(
+  repeatingInvoiceId: string,
+): Promise<XeroClientResponse<RepeatingInvoice>> {
+  try {
+    const existing = await getRepeatingInvoice(repeatingInvoiceId);
+
+    if (!existing) {
+      return {
+        result: null,
+        isError: true,
+        error: "Repeating invoice not found.",
+      };
+    }
+
+    if (existing.status === RepeatingInvoice.StatusEnum.DELETED) {
+      return {
+        result: null,
+        isError: true,
+        error: "Repeating invoice is already deleted.",
+      };
+    }
+
+    const deleted = await deleteRepeatingInvoice(repeatingInvoiceId);
+
+    if (!deleted) {
+      throw new Error("Repeating invoice delete failed.");
+    }
+
+    return {
+      result: deleted,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/get-xero-repeating-invoice.handler.test.ts
+++ b/src/handlers/get-xero-repeating-invoice.handler.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { getXeroRepeatingInvoice } from "./get-xero-repeating-invoice.handler.js";
+
+const repeatingInvoice = {
+  repeatingInvoiceID: "ri-1",
+  status: "DRAFT",
+  lineItems: [{ description: "Retainer", quantity: 1, unitAmount: 500 }],
+};
+
+describe("getXeroRepeatingInvoice", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("retrieves a repeating invoice by ID", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [repeatingInvoice] },
+    });
+
+    const result = await getXeroRepeatingInvoice("ri-1");
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result.repeatingInvoiceID).toBe("ri-1");
+    expect(mockAccountingApi.getRepeatingInvoice).toHaveBeenCalledWith(
+      "tenant-1",
+      "ri-1",
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("returns an error when Xero returns no repeating invoice", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [] },
+    });
+
+    const result = await getXeroRepeatingInvoice("missing");
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Repeating invoice not found.",
+    });
+  });
+
+  it("returns a formatted error when the get call fails", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockRejectedValue(
+      new Error("not authorised"),
+    );
+
+    const result = await getXeroRepeatingInvoice("ri-1");
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "not authorised",
+    });
+  });
+});

--- a/src/handlers/get-xero-repeating-invoice.handler.ts
+++ b/src/handlers/get-xero-repeating-invoice.handler.ts
@@ -1,0 +1,50 @@
+import { RepeatingInvoice } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function fetchRepeatingInvoice(
+  repeatingInvoiceId: string,
+): Promise<RepeatingInvoice | undefined> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getRepeatingInvoice(
+    xeroClient.tenantId,
+    repeatingInvoiceId,
+    getClientHeaders(),
+  );
+
+  return response.body.repeatingInvoices?.[0];
+}
+
+/**
+ * Retrieve a single repeating invoice template from Xero
+ */
+export async function getXeroRepeatingInvoice(
+  repeatingInvoiceId: string,
+): Promise<XeroClientResponse<RepeatingInvoice>> {
+  try {
+    const repeatingInvoice = await fetchRepeatingInvoice(repeatingInvoiceId);
+
+    if (!repeatingInvoice) {
+      return {
+        result: null,
+        isError: true,
+        error: "Repeating invoice not found.",
+      };
+    }
+
+    return {
+      result: repeatingInvoice,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-repeating-invoices.handler.test.ts
+++ b/src/handlers/list-xero-repeating-invoices.handler.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import {
+  buildRepeatingInvoiceWhere,
+  listXeroRepeatingInvoices,
+} from "./list-xero-repeating-invoices.handler.js";
+
+const repeatingInvoices = Array.from({ length: 12 }, (_, index) => ({
+  repeatingInvoiceID: `ri-${index + 1}`,
+  status: "AUTHORISED",
+  total: 100 + index,
+}));
+
+describe("buildRepeatingInvoiceWhere", () => {
+  it("returns undefined when no filters are provided", () => {
+    expect(buildRepeatingInvoiceWhere({})).toBeUndefined();
+  });
+
+  it("combines contact, status, and type filters", () => {
+    expect(
+      buildRepeatingInvoiceWhere({
+        contactId: "430fa14a-f945-44d3-9f97-5df5e28441b8",
+        status: "DRAFT",
+        type: "ACCREC",
+      }),
+    ).toBe(
+      'Contact.ContactID=guid("430fa14a-f945-44d3-9f97-5df5e28441b8") AND Status=="DRAFT" AND Type=="ACCREC"',
+    );
+  });
+
+  it("rejects a non-GUID contactId", () => {
+    expect(() =>
+      buildRepeatingInvoiceWhere({ contactId: 'x") OR Status=="DRAFT' }),
+    ).toThrow("contactId must be a Xero GUID.");
+  });
+});
+
+describe("listXeroRepeatingInvoices", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("lists the first page of repeating invoices by default", async () => {
+    mockAccountingApi.getRepeatingInvoices.mockResolvedValue({
+      body: { repeatingInvoices },
+    });
+
+    const result = await listXeroRepeatingInvoices();
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toHaveLength(10);
+    expect(result.result[0].repeatingInvoiceID).toBe("ri-1");
+    expect(result.result[9].repeatingInvoiceID).toBe("ri-10");
+    expect(mockAccountingApi.getRepeatingInvoices).toHaveBeenCalledWith(
+      "tenant-1",
+      undefined,
+      undefined,
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("returns the second page from the locally sliced result set", async () => {
+    mockAccountingApi.getRepeatingInvoices.mockResolvedValue({
+      body: { repeatingInvoices },
+    });
+
+    const result = await listXeroRepeatingInvoices({ page: 2 });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toHaveLength(2);
+    expect(result.result.map((item) => item.repeatingInvoiceID)).toEqual([
+      "ri-11",
+      "ri-12",
+    ]);
+  });
+
+  it("forwards status, type, and contact filters", async () => {
+    mockAccountingApi.getRepeatingInvoices.mockResolvedValue({
+      body: { repeatingInvoices: [] },
+    });
+
+    await listXeroRepeatingInvoices({
+      page: 1,
+      contactId: "430fa14a-f945-44d3-9f97-5df5e28441b8",
+      status: "DRAFT",
+      type: "ACCPAY",
+    });
+
+    expect(mockAccountingApi.getRepeatingInvoices).toHaveBeenCalledWith(
+      "tenant-1",
+      'Contact.ContactID=guid("430fa14a-f945-44d3-9f97-5df5e28441b8") AND Status=="DRAFT" AND Type=="ACCPAY"',
+      undefined,
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("returns an empty list when Xero omits repeatingInvoices", async () => {
+    mockAccountingApi.getRepeatingInvoices.mockResolvedValue({ body: {} });
+
+    const result = await listXeroRepeatingInvoices({ page: 1 });
+
+    expect(result).toEqual({
+      result: [],
+      isError: false,
+      error: null,
+    });
+  });
+
+  it("returns a formatted error when the list call fails", async () => {
+    mockAccountingApi.getRepeatingInvoices.mockRejectedValue(
+      new Error("rate limited"),
+    );
+
+    const result = await listXeroRepeatingInvoices({ page: 1 });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "rate limited",
+    });
+  });
+});

--- a/src/handlers/list-xero-repeating-invoices.handler.ts
+++ b/src/handlers/list-xero-repeating-invoices.handler.ts
@@ -1,0 +1,85 @@
+import { RepeatingInvoice } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import {
+  REPEATING_INVOICE_PAGE_SIZE,
+  RepeatingInvoiceStatus,
+  RepeatingInvoiceType,
+} from "../types/repeating-invoice.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+const GUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface ListRepeatingInvoicesParams {
+  page?: number;
+  contactId?: string;
+  status?: RepeatingInvoiceStatus;
+  type?: RepeatingInvoiceType;
+}
+
+export function buildRepeatingInvoiceWhere(
+  params: ListRepeatingInvoicesParams,
+): string | undefined {
+  const parts: string[] = [];
+
+  if (params.contactId) {
+    if (!GUID_RE.test(params.contactId)) {
+      throw new Error("contactId must be a Xero GUID.");
+    }
+    parts.push(`Contact.ContactID=guid("${params.contactId}")`);
+  }
+
+  if (params.status) {
+    parts.push(`Status=="${params.status}"`);
+  }
+
+  if (params.type) {
+    parts.push(`Type=="${params.type}"`);
+  }
+
+  return parts.length > 0 ? parts.join(" AND ") : undefined;
+}
+
+async function getRepeatingInvoices(
+  params: ListRepeatingInvoicesParams,
+): Promise<RepeatingInvoice[]> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getRepeatingInvoices(
+    xeroClient.tenantId,
+    buildRepeatingInvoiceWhere(params),
+    undefined,
+    getClientHeaders(),
+  );
+
+  const all = response.body.repeatingInvoices ?? [];
+  const page = params.page && params.page > 0 ? params.page : 1;
+  const start = (page - 1) * REPEATING_INVOICE_PAGE_SIZE;
+  return all.slice(start, start + REPEATING_INVOICE_PAGE_SIZE);
+}
+
+/**
+ * List repeating invoice templates from Xero.
+ * The Accounting API does not paginate this endpoint, so results are sliced locally.
+ */
+export async function listXeroRepeatingInvoices(
+  params: ListRepeatingInvoicesParams = {},
+): Promise<XeroClientResponse<RepeatingInvoice[]>> {
+  try {
+    const repeatingInvoices = await getRepeatingInvoices(params);
+
+    return {
+      result: repeatingInvoices,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/update-xero-repeating-invoice.handler.test.ts
+++ b/src/handlers/update-xero-repeating-invoice.handler.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { updateXeroRepeatingInvoice } from "./update-xero-repeating-invoice.handler.js";
+
+const existingDraft = {
+  repeatingInvoiceID: "ri-1",
+  status: "DRAFT",
+  contact: { contactID: "contact-1", name: "Northwind" },
+};
+
+const updatedRepeatingInvoice = {
+  ...existingDraft,
+  reference: "RETAINER-2",
+  total: 600,
+};
+
+describe("updateXeroRepeatingInvoice", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("updates a draft repeating invoice", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [existingDraft] },
+    });
+    mockAccountingApi.updateRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [updatedRepeatingInvoice] },
+    });
+
+    const result = await updateXeroRepeatingInvoice({
+      repeatingInvoiceId: "ri-1",
+      reference: "RETAINER-2",
+      lineItems: [
+        {
+          description: "Retainer",
+          quantity: 1,
+          unitAmount: 600,
+          accountCode: "200",
+          taxType: "OUTPUT2",
+        },
+      ],
+    });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result.reference).toBe("RETAINER-2");
+    expect(mockAccountingApi.updateRepeatingInvoice).toHaveBeenCalledWith(
+      "tenant-1",
+      "ri-1",
+      {
+        repeatingInvoices: [
+          expect.objectContaining({
+            reference: "RETAINER-2",
+            lineItems: [
+              expect.objectContaining({
+                description: "Retainer",
+                unitAmount: 600,
+              }),
+            ],
+          }),
+        ],
+      },
+      undefined,
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it("allows updates to authorised repeating invoices", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [{ ...existingDraft, status: "AUTHORISED" }] },
+    });
+    mockAccountingApi.updateRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [updatedRepeatingInvoice] },
+    });
+
+    const result = await updateXeroRepeatingInvoice({
+      repeatingInvoiceId: "ri-1",
+      schedule: { period: 2, unit: "MONTHLY" },
+    });
+
+    expect(result.isError).toBe(false);
+    const payload = mockAccountingApi.updateRepeatingInvoice.mock.calls[0][2];
+    expect(payload.repeatingInvoices[0].schedule).toMatchObject({
+      period: 2,
+      unit: "MONTHLY",
+    });
+  });
+
+  it("rejects deleted repeating invoices", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [{ ...existingDraft, status: "DELETED" }] },
+    });
+
+    const result = await updateXeroRepeatingInvoice({
+      repeatingInvoiceId: "ri-1",
+      reference: "nope",
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error:
+        "Cannot update repeating invoice because it is DELETED. Only DRAFT and AUTHORISED repeating invoices can be updated.",
+    });
+    expect(mockAccountingApi.updateRepeatingInvoice).not.toHaveBeenCalled();
+  });
+
+  it("can authorise a draft repeating invoice", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [existingDraft] },
+    });
+    mockAccountingApi.updateRepeatingInvoice.mockResolvedValue({
+      body: {
+        repeatingInvoices: [{ ...existingDraft, status: "AUTHORISED" }],
+      },
+    });
+
+    const result = await updateXeroRepeatingInvoice({
+      repeatingInvoiceId: "ri-1",
+      status: "AUTHORISED",
+    });
+
+    expect(result.isError).toBe(false);
+    const payload = mockAccountingApi.updateRepeatingInvoice.mock.calls[0][2];
+    expect(payload.repeatingInvoices[0].status).toBe("AUTHORISED");
+  });
+
+  it("returns an error when the existing repeating invoice cannot be loaded", async () => {
+    mockAccountingApi.getRepeatingInvoice.mockResolvedValue({
+      body: { repeatingInvoices: [] },
+    });
+
+    const result = await updateXeroRepeatingInvoice({
+      repeatingInvoiceId: "missing",
+      reference: "x",
+    });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Repeating invoice not found.",
+    });
+  });
+});

--- a/src/handlers/update-xero-repeating-invoice.handler.ts
+++ b/src/handlers/update-xero-repeating-invoice.handler.ts
@@ -1,0 +1,145 @@
+import { LineAmountTypes, RepeatingInvoice, Schedule } from "xero-node";
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import {
+  RepeatingInvoiceLineAmountTypes,
+  RepeatingInvoiceLineItem,
+  RepeatingInvoiceScheduleInput,
+  RepeatingInvoiceStatus,
+  RepeatingInvoiceType,
+} from "../types/repeating-invoice.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface UpdateRepeatingInvoiceParams {
+  repeatingInvoiceId: string;
+  contactId?: string;
+  lineItems?: RepeatingInvoiceLineItem[];
+  schedule?: Partial<RepeatingInvoiceScheduleInput>;
+  type?: RepeatingInvoiceType;
+  reference?: string;
+  status?: RepeatingInvoiceStatus;
+  lineAmountTypes?: RepeatingInvoiceLineAmountTypes;
+}
+
+function mapLineAmountTypes(
+  lineAmountTypes?: RepeatingInvoiceLineAmountTypes,
+): LineAmountTypes | undefined {
+  if (!lineAmountTypes) {
+    return undefined;
+  }
+  if (lineAmountTypes === "Inclusive") {
+    return LineAmountTypes.Inclusive;
+  }
+  if (lineAmountTypes === "NoTax") {
+    return LineAmountTypes.NoTax;
+  }
+  return LineAmountTypes.Exclusive;
+}
+
+async function getRepeatingInvoice(
+  repeatingInvoiceId: string,
+): Promise<RepeatingInvoice | undefined> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getRepeatingInvoice(
+    xeroClient.tenantId,
+    repeatingInvoiceId,
+    getClientHeaders(),
+  );
+
+  return response.body.repeatingInvoices?.[0];
+}
+
+function mapSchedule(
+  schedule?: Partial<RepeatingInvoiceScheduleInput>,
+): Schedule | undefined {
+  if (!schedule) {
+    return undefined;
+  }
+
+  return {
+    period: schedule.period,
+    unit: schedule.unit as Schedule.UnitEnum | undefined,
+    dueDate: schedule.dueDate,
+    dueDateType: schedule.dueDateType as Schedule.DueDateTypeEnum | undefined,
+    startDate: schedule.startDate,
+    endDate: schedule.endDate,
+  };
+}
+
+async function updateRepeatingInvoice(
+  params: UpdateRepeatingInvoiceParams,
+): Promise<RepeatingInvoice | undefined> {
+  const repeatingInvoice: RepeatingInvoice = {
+    lineItems: params.lineItems,
+    schedule: mapSchedule(params.schedule),
+    reference: params.reference,
+    contact: params.contactId ? { contactID: params.contactId } : undefined,
+    type: params.type as RepeatingInvoice.TypeEnum | undefined,
+    status: params.status as RepeatingInvoice.StatusEnum | undefined,
+    lineAmountTypes: mapLineAmountTypes(params.lineAmountTypes),
+  };
+
+  const response = await xeroClient.accountingApi.updateRepeatingInvoice(
+    xeroClient.tenantId,
+    params.repeatingInvoiceId,
+    {
+      repeatingInvoices: [repeatingInvoice],
+    },
+    undefined,
+    getClientHeaders(),
+  );
+
+  return response.body.repeatingInvoices?.[0];
+}
+
+/**
+ * Update an existing draft or authorised repeating invoice template in Xero
+ */
+export async function updateXeroRepeatingInvoice(
+  params: UpdateRepeatingInvoiceParams,
+): Promise<XeroClientResponse<RepeatingInvoice>> {
+  try {
+    const existing = await getRepeatingInvoice(params.repeatingInvoiceId);
+
+    if (!existing) {
+      return {
+        result: null,
+        isError: true,
+        error: "Repeating invoice not found.",
+      };
+    }
+
+    const currentStatus = existing.status;
+
+    if (
+      currentStatus !== RepeatingInvoice.StatusEnum.DRAFT &&
+      currentStatus !== RepeatingInvoice.StatusEnum.AUTHORISED
+    ) {
+      return {
+        result: null,
+        isError: true,
+        error: `Cannot update repeating invoice because it is ${currentStatus ?? "unknown"}. Only DRAFT and AUTHORISED repeating invoices can be updated.`,
+      };
+    }
+
+    const updated = await updateRepeatingInvoice(params);
+
+    if (!updated) {
+      throw new Error("Repeating invoice update failed.");
+    }
+
+    return {
+      result: updated,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/helpers/__tests__/format-repeating-invoice.test.ts
+++ b/src/helpers/__tests__/format-repeating-invoice.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { formatRepeatingInvoice } from "../format-repeating-invoice.js";
+
+describe("formatRepeatingInvoice", () => {
+  it("formats core fields and omits missing optionals", () => {
+    const text = formatRepeatingInvoice({
+      repeatingInvoiceID: "ri-1",
+      type: "ACCREC" as never,
+      status: "AUTHORISED" as never,
+      total: 5750,
+      contact: { contactID: "c-1", name: "Liam Gallagher" },
+    });
+
+    expect(text).toContain("ID: ri-1");
+    expect(text).toContain("Type: ACCREC");
+    expect(text).toContain("Status: AUTHORISED");
+    expect(text).toContain("Contact: Liam Gallagher (c-1)");
+    expect(text).toContain("Total: 5750");
+    expect(text).not.toContain("Reference:");
+    expect(text).not.toContain("Line Items:");
+    expect(text).not.toContain("Schedule:");
+  });
+
+  it("formats the schedule and line items when present", () => {
+    const text = formatRepeatingInvoice(
+      {
+        repeatingInvoiceID: "ri-1",
+        schedule: {
+          period: 1,
+          unit: "MONTHLY" as never,
+          dueDate: 10,
+          dueDateType: "OFFOLLOWINGMONTH" as never,
+          startDate: "2026-01-01",
+          nextScheduledDate: "2026-02-01",
+          endDate: "2026-12-01",
+        },
+        lineItems: [
+          {
+            description: "Retainer",
+            quantity: 1,
+            unitAmount: 500,
+            accountCode: "200",
+            taxType: "OUTPUT2",
+            lineAmount: 500,
+          },
+        ],
+      },
+      { includeLineItems: true },
+    );
+
+    expect(text).toContain("Schedule:");
+    expect(text).toContain("every 1 monthly");
+    expect(text).toContain("due 10 OFFOLLOWINGMONTH");
+    expect(text).toContain("Start Date: 2026-01-01");
+    expect(text).toContain("Next Scheduled Date: 2026-02-01");
+    expect(text).toContain("End Date: 2026-12-01");
+    expect(text).toContain("Line Items:");
+    expect(text).toContain("Description: Retainer");
+  });
+});

--- a/src/helpers/format-repeating-invoice.ts
+++ b/src/helpers/format-repeating-invoice.ts
@@ -1,0 +1,67 @@
+import { RepeatingInvoice, Schedule } from "xero-node";
+import { formatLineItem } from "./format-line-item.js";
+
+function formatSchedule(schedule?: Schedule): string | null {
+  if (!schedule) {
+    return null;
+  }
+
+  const cadence =
+    schedule.period != null && schedule.unit
+      ? `every ${schedule.period} ${String(schedule.unit).toLowerCase()}`
+      : null;
+  const due =
+    schedule.dueDate != null && schedule.dueDateType
+      ? `due ${schedule.dueDate} ${schedule.dueDateType}`
+      : null;
+
+  return [
+    "Schedule:",
+    cadence,
+    due,
+    schedule.startDate ? `Start Date: ${schedule.startDate}` : null,
+    schedule.nextScheduledDate
+      ? `Next Scheduled Date: ${schedule.nextScheduledDate}`
+      : null,
+    schedule.endDate ? `End Date: ${schedule.endDate}` : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export const formatRepeatingInvoice = (
+  repeatingInvoice: RepeatingInvoice,
+  options?: { includeLineItems?: boolean },
+): string => {
+  return [
+    `ID: ${repeatingInvoice.repeatingInvoiceID || repeatingInvoice.iD}`,
+    `Type: ${repeatingInvoice.type || "Unknown"}`,
+    `Status: ${repeatingInvoice.status || "Unknown"}`,
+    repeatingInvoice.reference
+      ? `Reference: ${repeatingInvoice.reference}`
+      : null,
+    repeatingInvoice.contact
+      ? `Contact: ${repeatingInvoice.contact.name} (${repeatingInvoice.contact.contactID})`
+      : null,
+    formatSchedule(repeatingInvoice.schedule),
+    repeatingInvoice.lineAmountTypes
+      ? `Line Amount Types: ${repeatingInvoice.lineAmountTypes}`
+      : null,
+    repeatingInvoice.subTotal != null
+      ? `Sub Total: ${repeatingInvoice.subTotal}`
+      : null,
+    repeatingInvoice.totalTax != null
+      ? `Total Tax: ${repeatingInvoice.totalTax}`
+      : null,
+    `Total: ${repeatingInvoice.total || 0}`,
+    repeatingInvoice.currencyCode
+      ? `Currency: ${repeatingInvoice.currencyCode}`
+      : null,
+    repeatingInvoice.hasAttachments ? "Has Attachments: Yes" : null,
+    options?.includeLineItems
+      ? `Line Items:\n${repeatingInvoice.lineItems?.map(formatLineItem).join("\n---\n") || "None"}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+};

--- a/src/tools/create/create-repeating-invoice.tool.ts
+++ b/src/tools/create/create-repeating-invoice.tool.ts
@@ -1,0 +1,153 @@
+import { z } from "zod";
+import { createXeroRepeatingInvoice } from "../../handlers/create-xero-repeating-invoice.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatRepeatingInvoice } from "../../helpers/format-repeating-invoice.js";
+
+const trackingSchema = z.object({
+  name: z
+    .string()
+    .describe(
+      "The name of the tracking category. Can be obtained from the list-tracking-categories tool",
+    ),
+  option: z
+    .string()
+    .describe(
+      "The name of the tracking option. Can be obtained from the list-tracking-categories tool",
+    ),
+  trackingCategoryID: z
+    .string()
+    .describe(
+      "The ID of the tracking category. Can be obtained from the list-tracking-categories tool",
+    ),
+});
+
+const lineItemSchema = z.object({
+  description: z.string().describe("The description of the line item"),
+  quantity: z.number().describe("The quantity of the line item"),
+  unitAmount: z.number().describe("The price per unit of the line item"),
+  accountCode: z
+    .string()
+    .describe(
+      "The account code of the line item - can be obtained from the list-accounts tool",
+    ),
+  taxType: z
+    .string()
+    .describe(
+      "The tax type of the line item - can be obtained from the list-tax-rates tool",
+    ),
+  itemCode: z
+    .string()
+    .describe(
+      "The item code of the line item - can be obtained from the list-items tool. \
+If the item is not listed, add without an item code and ask the user if they would like to add an item code.",
+    )
+    .optional(),
+  tracking: z
+    .array(trackingSchema)
+    .describe(
+      "Up to 2 tracking categories and options can be added to the line item. \
+Can be obtained from the list-tracking-categories tool. Only use if prompted by the user.",
+    )
+    .optional(),
+});
+
+const scheduleSchema = z.object({
+  period: z
+    .number()
+    .int()
+    .positive()
+    .describe(
+      "How often the invoice repeats, used with unit. 1 means every week or month.",
+    ),
+  unit: z
+    .enum(["WEEKLY", "MONTHLY"])
+    .describe("The schedule unit. WEEKLY or MONTHLY."),
+  dueDate: z
+    .number()
+    .int()
+    .describe(
+      "Integer used with dueDateType, for example 10 with OFFOLLOWINGMONTH means the 10th of the following month.",
+    ),
+  dueDateType: z
+    .enum([
+      "DAYSAFTERBILLDATE",
+      "DAYSAFTERBILLMONTH",
+      "DAYSAFTERINVOICEDATE",
+      "DAYSAFTERINVOICEMONTH",
+      "OFCURRENTMONTH",
+      "OFFOLLOWINGMONTH",
+    ])
+    .describe("How the due date is calculated from each generated invoice."),
+  startDate: z
+    .string()
+    .describe("The first invoice date for this schedule (YYYY-MM-DD)."),
+  endDate: z
+    .string()
+    .optional()
+    .describe("Optional last invoice date for this schedule (YYYY-MM-DD)."),
+});
+
+const CreateRepeatingInvoiceTool = CreateXeroTool(
+  "create-repeating-invoice",
+  "Create a repeating invoice template in Xero. \
+Creates as DRAFT unless status AUTHORISED is supplied. \
+AUTHORISED templates start generating invoices on the schedule. \
+ACCREC is a sales invoice; ACCPAY is a bill.",
+  {
+    contactId: z
+      .string()
+      .describe(
+        "The ID of the contact to create the repeating invoice for. \
+Can be obtained from the list-contacts tool.",
+      ),
+    lineItems: z.array(lineItemSchema),
+    schedule: scheduleSchema,
+    type: z
+      .enum(["ACCREC", "ACCPAY"])
+      .optional()
+      .describe(
+        "ACCREC is sales invoices / accounts receivable. ACCPAY is bills / accounts payable. Defaults to ACCREC.",
+      ),
+    reference: z
+      .string()
+      .optional()
+      .describe("ACCREC only – additional reference number."),
+    status: z
+      .enum(["DRAFT", "AUTHORISED"])
+      .optional()
+      .describe(
+        "DRAFT (default) does not generate invoices. AUTHORISED starts generating invoices on the schedule.",
+      ),
+    lineAmountTypes: z
+      .enum(["Exclusive", "Inclusive", "NoTax"])
+      .optional()
+      .describe("How tax is applied to line amounts. Defaults to Exclusive."),
+  },
+  async (params) => {
+    const result = await createXeroRepeatingInvoice(params);
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error creating repeating invoice: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Repeating invoice created successfully:",
+            formatRepeatingInvoice(result.result, { includeLineItems: true }),
+          ].join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default CreateRepeatingInvoiceTool;

--- a/src/tools/create/index.ts
+++ b/src/tools/create/index.ts
@@ -7,6 +7,7 @@ import CreateManualJournalTool from "./create-manual-journal.tool.js";
 import CreatePaymentTool from "./create-payment.tool.js";
 import CreatePayrollTimesheetTool from "./create-payroll-timesheet.tool.js";
 import CreateQuoteTool from "./create-quote.tool.js";
+import CreateRepeatingInvoiceTool from "./create-repeating-invoice.tool.js";
 import CreateTrackingCategoryTool from "./create-tracking-category.tool.js";
 import CreateTrackingOptionsTool from "./create-tracking-options.tool.js";
 
@@ -16,6 +17,7 @@ export const CreateTools = [
   CreateManualJournalTool,
   CreateInvoiceTool,
   CreateQuoteTool,
+  CreateRepeatingInvoiceTool,
   CreatePaymentTool,
   CreateItemTool,
   CreateBankTransactionTool,

--- a/src/tools/delete/delete-repeating-invoice.tool.ts
+++ b/src/tools/delete/delete-repeating-invoice.tool.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { deleteXeroRepeatingInvoice } from "../../handlers/delete-xero-repeating-invoice.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatRepeatingInvoice } from "../../helpers/format-repeating-invoice.js";
+
+const DeleteRepeatingInvoiceTool = CreateXeroTool(
+  "delete-repeating-invoice",
+  `Delete a repeating invoice template in Xero by setting its status to DELETED.
+  Already-generated invoices are not deleted and must be handled separately.`,
+  {
+    repeatingInvoiceId: z
+      .string()
+      .describe("The ID of the repeating invoice template to delete."),
+  },
+  async ({ repeatingInvoiceId }) => {
+    const response = await deleteXeroRepeatingInvoice(repeatingInvoiceId);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error deleting repeating invoice: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            `Successfully deleted repeating invoice with ID: ${repeatingInvoiceId}`,
+            formatRepeatingInvoice(response.result),
+          ].join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default DeleteRepeatingInvoiceTool;

--- a/src/tools/delete/index.ts
+++ b/src/tools/delete/index.ts
@@ -1,5 +1,7 @@
 import DeletePayrollTimesheetTool from "./delete-payroll-timesheet.tool.js";
+import DeleteRepeatingInvoiceTool from "./delete-repeating-invoice.tool.js";
 
 export const DeleteTools = [
-  DeletePayrollTimesheetTool
+  DeletePayrollTimesheetTool,
+  DeleteRepeatingInvoiceTool,
 ];

--- a/src/tools/get/get-repeating-invoice.tool.ts
+++ b/src/tools/get/get-repeating-invoice.tool.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { getXeroRepeatingInvoice } from "../../handlers/get-xero-repeating-invoice.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatRepeatingInvoice } from "../../helpers/format-repeating-invoice.js";
+
+const GetRepeatingInvoiceTool = CreateXeroTool(
+  "get-repeating-invoice",
+  `Retrieve a single repeating invoice template from Xero by ID.
+  Line items and the full schedule are included in the response.`,
+  {
+    repeatingInvoiceId: z
+      .string()
+      .describe("The ID of the repeating invoice template to retrieve."),
+  },
+  async ({ repeatingInvoiceId }) => {
+    const response = await getXeroRepeatingInvoice(repeatingInvoiceId);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error retrieving repeating invoice: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: formatRepeatingInvoice(response.result, {
+            includeLineItems: true,
+          }),
+        },
+      ],
+    };
+  },
+);
+
+export default GetRepeatingInvoiceTool;

--- a/src/tools/get/index.ts
+++ b/src/tools/get/index.ts
@@ -1,5 +1,7 @@
 import GetPayrollTimesheetTool from "./get-payroll-timesheet.tool.js";
+import GetRepeatingInvoiceTool from "./get-repeating-invoice.tool.js";
 
 export const GetTools = [
   GetPayrollTimesheetTool,
+  GetRepeatingInvoiceTool,
 ];

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -23,6 +23,7 @@ import ListPayrollLeaveTypesTool from "./list-payroll-leave-types.tool.js";
 import ListPayrollTimesheetsTool from "./list-payroll-timesheets.tool.js";
 import ListProfitAndLossTool from "./list-profit-and-loss.tool.js";
 import ListQuotesTool from "./list-quotes.tool.js";
+import ListRepeatingInvoicesTool from "./list-repeating-invoices.tool.js";
 import ListReportBalanceSheetTool from "./list-report-balance-sheet.tool.js";
 import ListTaxRatesTool from "./list-tax-rates.tool.js";
 import ListTrackingCategoriesTool from "./list-tracking-categories.tool.js";
@@ -37,6 +38,7 @@ export const ListTools = [
   ListItemsTool,
   ListManualJournalsTool,
   ListQuotesTool,
+  ListRepeatingInvoicesTool,
   ListTaxRatesTool,
   ListTrialBalanceTool,
   ListPaymentsTool,

--- a/src/tools/list/list-repeating-invoices.tool.ts
+++ b/src/tools/list/list-repeating-invoices.tool.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { listXeroRepeatingInvoices } from "../../handlers/list-xero-repeating-invoices.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatRepeatingInvoice } from "../../helpers/format-repeating-invoice.js";
+
+const ListRepeatingInvoicesTool = CreateXeroTool(
+  "list-repeating-invoices",
+  `List repeating invoice templates in Xero.
+  Ask the user if they want to filter by contact, status, or type (sales invoices vs bills) before running.
+  Ask the user if they want the next page after running this tool if 10 repeating invoices are returned.
+  If they do, call this tool again with the next page number and the same filters.
+  The Xero Repeating Invoices endpoint is not server-paginated; this tool returns 10 templates per page.`,
+  {
+    page: z
+      .number()
+      .describe("The page of repeating invoices to retrieve (10 per page)."),
+    contactId: z
+      .string()
+      .optional()
+      .describe(
+        "Filter to repeating invoices for a specific contact. Can be obtained from the list-contacts tool.",
+      ),
+    status: z
+      .enum(["DRAFT", "AUTHORISED", "DELETED"])
+      .optional()
+      .describe("Filter by repeating invoice status."),
+    type: z
+      .enum(["ACCREC", "ACCPAY"])
+      .optional()
+      .describe(
+        "ACCREC is sales invoices / accounts receivable. ACCPAY is bills / accounts payable.",
+      ),
+  },
+  async ({ page, contactId, status, type }) => {
+    const response = await listXeroRepeatingInvoices({
+      page,
+      contactId,
+      status,
+      type,
+    });
+    if (response.error !== null) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing repeating invoices: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const repeatingInvoices = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${repeatingInvoices?.length || 0} repeating invoices:`,
+        },
+        ...(repeatingInvoices?.map((repeatingInvoice) => ({
+          type: "text" as const,
+          text: formatRepeatingInvoice(repeatingInvoice),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListRepeatingInvoicesTool;

--- a/src/tools/update/index.ts
+++ b/src/tools/update/index.ts
@@ -10,6 +10,7 @@ import UpdatePayrollTimesheetLineTool
   from "./update-payroll-timesheet-update-line.tool.js";
 import UpdateManualJournalTool from "./update-manual-journal-tool.js";
 import UpdateQuoteTool from "./update-quote.tool.js";
+import UpdateRepeatingInvoiceTool from "./update-repeating-invoice.tool.js";
 import UpdateTrackingCategoryTool from "./update-tracking-category.tool.js";
 import UpdateTrackingOptionsTool from "./update-tracking-options.tool.js";
 
@@ -19,6 +20,7 @@ export const UpdateTools = [
   UpdateInvoiceTool,
   UpdateManualJournalTool,
   UpdateQuoteTool,
+  UpdateRepeatingInvoiceTool,
   UpdateItemTool,
   UpdateBankTransactionTool,
   ApprovePayrollTimesheetTool,

--- a/src/tools/update/update-repeating-invoice.tool.ts
+++ b/src/tools/update/update-repeating-invoice.tool.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import { updateXeroRepeatingInvoice } from "../../handlers/update-xero-repeating-invoice.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatRepeatingInvoice } from "../../helpers/format-repeating-invoice.js";
+
+const trackingSchema = z.object({
+  name: z.string().describe("The name of the tracking category."),
+  option: z.string().describe("The name of the tracking option."),
+  trackingCategoryID: z.string().describe("The ID of the tracking category."),
+});
+
+const lineItemSchema = z.object({
+  description: z.string().describe("The description of the line item"),
+  quantity: z.number().describe("The quantity of the line item"),
+  unitAmount: z.number().describe("The price per unit of the line item"),
+  accountCode: z
+    .string()
+    .describe(
+      "The account code of the line item - can be obtained from the list-accounts tool",
+    ),
+  taxType: z
+    .string()
+    .describe(
+      "The tax type of the line item - can be obtained from the list-tax-rates tool",
+    ),
+  itemCode: z.string().optional(),
+  tracking: z.array(trackingSchema).optional(),
+});
+
+const scheduleSchema = z.object({
+  period: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("How often the invoice repeats, used with unit."),
+  unit: z.enum(["WEEKLY", "MONTHLY"]).optional(),
+  dueDate: z.number().int().optional(),
+  dueDateType: z
+    .enum([
+      "DAYSAFTERBILLDATE",
+      "DAYSAFTERBILLMONTH",
+      "DAYSAFTERINVOICEDATE",
+      "DAYSAFTERINVOICEMONTH",
+      "OFCURRENTMONTH",
+      "OFFOLLOWINGMONTH",
+    ])
+    .optional(),
+  startDate: z
+    .string()
+    .optional()
+    .describe("The first invoice date for this schedule (YYYY-MM-DD)."),
+  endDate: z
+    .string()
+    .optional()
+    .describe("Optional last invoice date for this schedule (YYYY-MM-DD)."),
+});
+
+const UpdateRepeatingInvoiceTool = CreateXeroTool(
+  "update-repeating-invoice",
+  "Update a repeating invoice template in Xero. Works on DRAFT and AUTHORISED templates. \
+  All line items must be provided when changing lines. Any line items not provided will be removed. \
+  Do not modify line items that have not been specified by the user. \
+  Schedule changes apply to future generated invoices only. \
+  Use status AUTHORISED to start generating invoices, or DELETED to delete the template.",
+  {
+    repeatingInvoiceId: z
+      .string()
+      .describe("The ID of the repeating invoice template to update."),
+    lineItems: z
+      .array(lineItemSchema)
+      .optional()
+      .describe(
+        "All line items must be provided. Any line items not provided will be removed. \
+Do not modify line items that have not been specified by the user.",
+      ),
+    schedule: scheduleSchema
+      .optional()
+      .describe("Replace or adjust the repeating schedule."),
+    reference: z.string().optional(),
+    contactId: z
+      .string()
+      .optional()
+      .describe("Replace the contact on the repeating invoice."),
+    type: z.enum(["ACCREC", "ACCPAY"]).optional(),
+    status: z
+      .enum(["DRAFT", "AUTHORISED", "DELETED"])
+      .optional()
+      .describe(
+        "AUTHORISED starts generating invoices. DELETED removes the template.",
+      ),
+    lineAmountTypes: z.enum(["Exclusive", "Inclusive", "NoTax"]).optional(),
+  },
+  async (params) => {
+    const result = await updateXeroRepeatingInvoice(params);
+    if (result.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error updating repeating invoice: ${result.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Repeating invoice updated successfully:",
+            formatRepeatingInvoice(result.result, { includeLineItems: true }),
+          ].join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default UpdateRepeatingInvoiceTool;

--- a/src/types/repeating-invoice.ts
+++ b/src/types/repeating-invoice.ts
@@ -1,0 +1,41 @@
+import { LineItemTracking } from "xero-node";
+
+export interface RepeatingInvoiceLineItem {
+  description: string;
+  quantity: number;
+  unitAmount: number;
+  accountCode: string;
+  taxType: string;
+  itemCode?: string;
+  tracking?: LineItemTracking[];
+}
+
+export type RepeatingInvoiceType = "ACCREC" | "ACCPAY";
+
+export type RepeatingInvoiceStatus = "DRAFT" | "AUTHORISED" | "DELETED";
+
+export type RepeatingInvoiceScheduleUnit = "WEEKLY" | "MONTHLY";
+
+export type RepeatingInvoiceDueDateType =
+  | "DAYSAFTERBILLDATE"
+  | "DAYSAFTERBILLMONTH"
+  | "DAYSAFTERINVOICEDATE"
+  | "DAYSAFTERINVOICEMONTH"
+  | "OFCURRENTMONTH"
+  | "OFFOLLOWINGMONTH";
+
+export type RepeatingInvoiceLineAmountTypes =
+  | "Exclusive"
+  | "Inclusive"
+  | "NoTax";
+
+export interface RepeatingInvoiceScheduleInput {
+  period: number;
+  unit: RepeatingInvoiceScheduleUnit;
+  dueDate: number;
+  dueDateType: RepeatingInvoiceDueDateType;
+  startDate: string;
+  endDate?: string;
+}
+
+export const REPEATING_INVOICE_PAGE_SIZE = 10;


### PR DESCRIPTION
## Summary

Closes #113.

Adds the five Repeating Invoices tools requested on that issue, using the existing invoice/quote tool pattern and the `xero-node` Accounting API:

- `list-repeating-invoices` — filter by contact, status, or type (`ACCREC` / `ACCPAY`)
- `get-repeating-invoice` — fetch one template, including line items and schedule
- `create-repeating-invoice` — create a template (`DRAFT` by default; `AUTHORISED` starts generating invoices)
- `update-repeating-invoice` — update `DRAFT` or `AUTHORISED` templates
- `delete-repeating-invoice` — set status to `DELETED` (Xero has no dedicated delete verb)

The list endpoint is not server-paginated, so results are sliced locally to 10 per page to match the other list tools.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (39 tests, including new handler and formatter coverage)
- [x] `npm run lint`
- [ ] Maintainer: create/list/update/delete a template against a Demo Company (needs `accounting.transactions` / `accounting.transactions.read`, or the equivalent invoice scopes on granular apps)