### PR TITLE
feat: include quote line items in list-quotes and add get-quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ payroll.timesheets
 - `list-manual-journals`: Retrieve a list of manual journals
 - `list-organisation-details`: Retrieve details about an organisation
 - `list-profit-and-loss`: Retrieve a profit and loss report
-- `list-quotes`: Retrieve a list of quotes
+- `list-quotes`: Retrieve a list of quotes, including line items
+- `get-quote`: Retrieve a single quote by ID or number, including line items
 - `list-tax-rates`: Retrieve a list of tax rates
 - `list-payments`: Retrieve a list of payments
 - `list-trial-balance`: Retrieve a trial balance report

--- a/src/handlers/__tests__/mock-xero-client.ts
+++ b/src/handlers/__tests__/mock-xero-client.ts
@@ -1,0 +1,23 @@
+import { vi } from "vitest";
+
+export const mockAccountingApi = {
+  getQuote: vi.fn(),
+  getQuotes: vi.fn(),
+};
+
+export const mockXeroClient = {
+  authenticate: vi.fn().mockResolvedValue(undefined),
+  tenantId: "tenant-1",
+  accountingApi: mockAccountingApi,
+  getShortCode: vi.fn().mockResolvedValue("!abc"),
+};
+
+export function resetXeroClientMocks() {
+  mockXeroClient.authenticate.mockClear();
+  mockXeroClient.authenticate.mockResolvedValue(undefined);
+  mockXeroClient.getShortCode.mockClear();
+  mockXeroClient.getShortCode.mockResolvedValue("!abc");
+  for (const fn of Object.values(mockAccountingApi)) {
+    fn.mockReset();
+  }
+}

--- a/src/handlers/get-xero-quote.handler.test.ts
+++ b/src/handlers/get-xero-quote.handler.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { getXeroQuote } from "./get-xero-quote.handler.js";
+
+const quote = {
+  quoteID: "q-1",
+  quoteNumber: "QU-0007",
+  lineItems: [{ description: "Training", quantity: 1, unitAmount: 500 }],
+};
+
+describe("getXeroQuote", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("fetches a quote by ID", async () => {
+    mockAccountingApi.getQuote.mockResolvedValue({
+      body: { quotes: [quote] },
+    });
+
+    const result = await getXeroQuote({ quoteId: "q-1" });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toEqual(quote);
+    expect(mockXeroClient.authenticate).toHaveBeenCalledOnce();
+    expect(mockAccountingApi.getQuote).toHaveBeenCalledWith(
+      "tenant-1",
+      "q-1",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+    expect(mockAccountingApi.getQuotes).not.toHaveBeenCalled();
+  });
+
+  it("fetches a quote by number when no ID is given", async () => {
+    mockAccountingApi.getQuotes.mockResolvedValue({
+      body: { quotes: [quote] },
+    });
+
+    const result = await getXeroQuote({ quoteNumber: "QU-0007" });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toEqual(quote);
+    expect(mockAccountingApi.getQuotes).toHaveBeenCalledWith(
+      "tenant-1",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      1,
+      undefined,
+      "QU-0007",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+  });
+
+  it("prefers quote ID when both identifiers are provided", async () => {
+    mockAccountingApi.getQuote.mockResolvedValue({
+      body: { quotes: [quote] },
+    });
+
+    await getXeroQuote({ quoteId: "q-1", quoteNumber: "QU-0007" });
+
+    expect(mockAccountingApi.getQuote).toHaveBeenCalledOnce();
+    expect(mockAccountingApi.getQuotes).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when neither identifier is provided", async () => {
+    const result = await getXeroQuote({});
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Provide a quoteId or quoteNumber.",
+    });
+    expect(mockAccountingApi.getQuote).not.toHaveBeenCalled();
+    expect(mockAccountingApi.getQuotes).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when Xero omits the quote", async () => {
+    mockAccountingApi.getQuote.mockResolvedValue({ body: { quotes: [] } });
+
+    const result = await getXeroQuote({ quoteId: "missing" });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Quote not found.",
+    });
+  });
+
+  it("returns a formatted error when the get call fails", async () => {
+    mockAccountingApi.getQuote.mockRejectedValue(new Error("not authorised"));
+
+    const result = await getXeroQuote({ quoteId: "q-1" });
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "not authorised",
+    });
+  });
+});

--- a/src/handlers/get-xero-quote.handler.ts
+++ b/src/handlers/get-xero-quote.handler.ts
@@ -1,0 +1,77 @@
+import { Quote } from "xero-node";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface GetXeroQuoteParams {
+  quoteId?: string;
+  quoteNumber?: string;
+}
+
+async function fetchQuoteById(quoteId: string): Promise<Quote | undefined> {
+  const response = await xeroClient.accountingApi.getQuote(
+    xeroClient.tenantId,
+    quoteId,
+    getClientHeaders(),
+  );
+
+  return response.body.quotes?.[0];
+}
+
+async function fetchQuoteByNumber(
+  quoteNumber: string,
+): Promise<Quote | undefined> {
+  const response = await xeroClient.accountingApi.getQuotes(
+    xeroClient.tenantId,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    1,
+    undefined,
+    quoteNumber,
+    getClientHeaders(),
+  );
+
+  return response.body.quotes?.[0];
+}
+
+/**
+ * Get a single quote from Xero, including line items.
+ */
+export async function getXeroQuote(
+  params: GetXeroQuoteParams,
+): Promise<XeroClientResponse<Quote>> {
+  try {
+    if (!params.quoteId && !params.quoteNumber) {
+      throw new Error("Provide a quoteId or quoteNumber.");
+    }
+
+    await xeroClient.authenticate();
+
+    const quote = params.quoteId
+      ? await fetchQuoteById(params.quoteId)
+      : await fetchQuoteByNumber(params.quoteNumber as string);
+
+    if (!quote) {
+      throw new Error("Quote not found.");
+    }
+
+    return {
+      result: quote,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/helpers/__tests__/format-quote.test.ts
+++ b/src/helpers/__tests__/format-quote.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { LineItem, Quote } from "xero-node";
+import {
+  formatQuote,
+  formatQuoteLineItem,
+  formatQuoteLineItems,
+} from "../format-quote.js";
+
+const lineItems: LineItem[] = [
+  {
+    itemCode: "Train-MS",
+    description: "Half day training - Microsoft Office",
+    quantity: 1,
+    unitAmount: 500,
+    accountCode: "400",
+    taxType: "NONE",
+    lineAmount: 500,
+    tracking: [{ name: "Avengers", option: "IronMan" }],
+  },
+  {
+    description: "Travel expenses",
+    quantity: 2,
+    unitAmount: 50,
+    accountCode: "400",
+    taxType: "NONE",
+    lineAmount: 100,
+  },
+];
+
+describe("formatQuoteLineItem", () => {
+  it("prints the fields needed to recreate a create-invoice line", () => {
+    expect(formatQuoteLineItem(lineItems[0], 0)).toBe(
+      [
+        "1.",
+        "Item Code: Train-MS",
+        "Description: Half day training - Microsoft Office",
+        "Quantity: 1",
+        "Unit Amount: 500",
+        "Account Code: 400",
+        "Tax Type: NONE",
+        "Line Amount: 500",
+        "Tracking: Avengers: IronMan",
+      ].join("\n"),
+    );
+  });
+
+  it("does not stringify item or tracking objects", () => {
+    const text = formatQuoteLineItem(
+      {
+        description: "Widget",
+        quantity: 1,
+        unitAmount: 10,
+        item: { code: "W1", name: "Widget" },
+        tracking: [{ name: "Region", option: "East" }],
+      },
+      0,
+    );
+
+    expect(text).not.toContain("[object Object]");
+    expect(text).toContain("Tracking: Region: East");
+  });
+});
+
+describe("formatQuoteLineItems", () => {
+  it("returns null when there are no line items", () => {
+    expect(formatQuoteLineItems(undefined)).toBeNull();
+    expect(formatQuoteLineItems([])).toBeNull();
+  });
+
+  it("numbers each line so they stay separate", () => {
+    const text = formatQuoteLineItems(lineItems);
+
+    expect(text).toContain("Line Items (2):");
+    expect(text).toContain("1.");
+    expect(text).toContain("2.");
+    expect(text).toContain("Travel expenses");
+  });
+});
+
+describe("formatQuote", () => {
+  it("includes header fields and every line item", () => {
+    const quote: Quote = {
+      quoteID: "q-1",
+      quoteNumber: "QU-0007",
+      contact: { contactID: "c-1", name: "ABC Limited" },
+      total: 600,
+      lineItems,
+    };
+
+    const text = formatQuote(quote);
+
+    expect(text).toContain("Quote ID: q-1");
+    expect(text).toContain("Quote Number: QU-0007");
+    expect(text).toContain("Contact: ABC Limited (c-1)");
+    expect(text).toContain("Half day training - Microsoft Office");
+    expect(text).toContain("Travel expenses");
+  });
+});

--- a/src/helpers/__tests__/vitest-setup.ts
+++ b/src/helpers/__tests__/vitest-setup.ts
@@ -1,0 +1,2 @@
+process.env.XERO_CLIENT_ID ??= "test-client-id";
+process.env.XERO_CLIENT_SECRET ??= "test-client-secret";

--- a/src/helpers/format-quote.ts
+++ b/src/helpers/format-quote.ts
@@ -1,0 +1,87 @@
+import { LineItem, LineItemTracking, Quote } from "xero-node";
+
+function formatTracking(tracking?: LineItemTracking[]): string | null {
+  if (!tracking?.length) {
+    return null;
+  }
+
+  const value = tracking
+    .map((entry) => {
+      const name = entry.name ?? "Unknown";
+      const option = entry.option ?? "Unknown";
+      return `${name}: ${option}`;
+    })
+    .join("; ");
+
+  return `Tracking: ${value}`;
+}
+
+export function formatQuoteLineItem(
+  lineItem: LineItem,
+  index: number,
+): string {
+  return [
+    `${index + 1}.`,
+    lineItem.itemCode ? `Item Code: ${lineItem.itemCode}` : null,
+    lineItem.description ? `Description: ${lineItem.description}` : null,
+    lineItem.quantity !== undefined ? `Quantity: ${lineItem.quantity}` : null,
+    lineItem.unitAmount !== undefined
+      ? `Unit Amount: ${lineItem.unitAmount}`
+      : null,
+    lineItem.accountCode ? `Account Code: ${lineItem.accountCode}` : null,
+    lineItem.taxType ? `Tax Type: ${lineItem.taxType}` : null,
+    lineItem.lineAmount !== undefined
+      ? `Line Amount: ${lineItem.lineAmount}`
+      : null,
+    lineItem.discountRate !== undefined
+      ? `Discount Rate: ${lineItem.discountRate}`
+      : null,
+    lineItem.discountAmount !== undefined
+      ? `Discount Amount: ${lineItem.discountAmount}`
+      : null,
+    formatTracking(lineItem.tracking),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function formatQuoteLineItems(lineItems?: LineItem[]): string | null {
+  if (!lineItems?.length) {
+    return null;
+  }
+
+  return [
+    `Line Items (${lineItems.length}):`,
+    ...lineItems.map((lineItem, index) => formatQuoteLineItem(lineItem, index)),
+  ].join("\n");
+}
+
+export function formatQuote(quote: Quote): string {
+  return [
+    `Quote ID: ${quote.quoteID}`,
+    `Quote Number: ${quote.quoteNumber}`,
+    quote.reference ? `Reference: ${quote.reference}` : null,
+    `Status: ${quote.status || "Unknown"}`,
+    quote.contact
+      ? `Contact: ${quote.contact.name} (${quote.contact.contactID})`
+      : null,
+    quote.dateString ? `Quote Date: ${quote.dateString}` : null,
+    quote.expiryDateString ? `Expiry Date: ${quote.expiryDateString}` : null,
+    quote.title ? `Title: ${quote.title}` : null,
+    quote.summary ? `Summary: ${quote.summary}` : null,
+    quote.terms ? `Terms: ${quote.terms}` : null,
+    quote.lineAmountTypes
+      ? `Line Amount Types: ${quote.lineAmountTypes}`
+      : null,
+    quote.subTotal ? `Sub Total: ${quote.subTotal}` : null,
+    quote.totalTax ? `Total Tax: ${quote.totalTax}` : null,
+    `Total: ${quote.total || 0}`,
+    quote.totalDiscount ? `Total Discount: ${quote.totalDiscount}` : null,
+    quote.currencyCode ? `Currency: ${quote.currencyCode}` : null,
+    quote.currencyRate ? `Currency Rate: ${quote.currencyRate}` : null,
+    quote.updatedDateUTC ? `Last Updated: ${quote.updatedDateUTC}` : null,
+    formatQuoteLineItems(quote.lineItems),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/src/tools/create/create-invoice.tool.ts
+++ b/src/tools/create/create-invoice.tool.ts
@@ -29,7 +29,8 @@ const CreateInvoiceTool = CreateXeroTool(
   "Create an invoice in Xero.\
  When an invoice is created, a deep link to the invoice in Xero is returned. \
  This deep link can be used to view the invoice in Xero directly. \
- This link should be displayed to the user.",
+ This link should be displayed to the user. \
+ When creating an invoice from a quote, first call get-quote or list-quotes, then pass each quote line item as its own invoice line. Do not collapse quote lines into a single line item.",
   {
     contactId: z.string().describe("The ID of the contact to create the invoice for. \
       Can be obtained from the list-contacts tool."),

--- a/src/tools/get/get-quote.tool.ts
+++ b/src/tools/get/get-quote.tool.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+import { getXeroQuote } from "../../handlers/get-xero-quote.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { DeepLinkType, getDeepLink } from "../../helpers/get-deeplink.js";
+import { formatQuote } from "../../helpers/format-quote.js";
+
+const GetQuoteTool = CreateXeroTool(
+  "get-quote",
+  `Get a single quote from Xero by quote ID or quote number, including every line item.
+Use this before creating an invoice from a quote. Pass each quote line to create-invoice as its own line item. Do not combine line items into one line.`,
+  {
+    quoteId: z
+      .string()
+      .optional()
+      .describe("The quote ID. Can be obtained from list-quotes."),
+    quoteNumber: z
+      .string()
+      .optional()
+      .describe("The quote number, for example QU-0001. Used when quoteId is not provided."),
+  },
+  async ({ quoteId, quoteNumber }) => {
+    const response = await getXeroQuote({ quoteId, quoteNumber });
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error retrieving quote: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const quote = response.result;
+
+    const deepLink = quote.quoteID
+      ? await getDeepLink(DeepLinkType.QUOTE, quote.quoteID)
+      : null;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [formatQuote(quote), deepLink ? `Link to view: ${deepLink}` : null]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default GetQuoteTool;

--- a/src/tools/get/index.ts
+++ b/src/tools/get/index.ts
@@ -1,5 +1,7 @@
+import GetQuoteTool from "./get-quote.tool.js";
 import GetPayrollTimesheetTool from "./get-payroll-timesheet.tool.js";
 
 export const GetTools = [
   GetPayrollTimesheetTool,
+  GetQuoteTool,
 ];

--- a/src/tools/list/list-quotes.tool.test.ts
+++ b/src/tools/list/list-quotes.tool.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { listXeroQuotes } = vi.hoisted(() => ({
+  listXeroQuotes: vi.fn(),
+}));
+
+vi.mock("../../handlers/list-xero-quotes.handler.js", () => ({
+  listXeroQuotes,
+}));
+
+import ListQuotesTool from "./list-quotes.tool.js";
+
+describe("list-quotes tool", () => {
+  beforeEach(() => {
+    listXeroQuotes.mockReset();
+  });
+
+  it("includes each quote line item instead of only totals", async () => {
+    listXeroQuotes.mockResolvedValue({
+      result: [
+        {
+          quoteID: "q-1",
+          quoteNumber: "QU-0007",
+          contact: { contactID: "c-1", name: "ABC Limited" },
+          total: 600,
+          lineItems: [
+            {
+              description: "Half day training - Microsoft Office",
+              quantity: 1,
+              unitAmount: 500,
+              accountCode: "400",
+              taxType: "NONE",
+            },
+            {
+              description: "Travel expenses",
+              quantity: 2,
+              unitAmount: 50,
+              accountCode: "400",
+              taxType: "NONE",
+            },
+          ],
+        },
+      ],
+      isError: false,
+      error: null,
+    });
+
+    const result = await ListQuotesTool().handler(
+      { page: 1 },
+      {} as never,
+    );
+
+    const text = result.content
+      .map((block) => ("text" in block ? block.text : ""))
+      .join("\n");
+
+    expect(text).toContain("Line Items (2):");
+    expect(text).toContain("Half day training - Microsoft Office");
+    expect(text).toContain("Travel expenses");
+    expect(text).toContain("Quantity: 1");
+    expect(text).toContain("Quantity: 2");
+  });
+});

--- a/src/tools/list/list-quotes.tool.ts
+++ b/src/tools/list/list-quotes.tool.ts
@@ -1,13 +1,15 @@
 import { z } from "zod";
 import { listXeroQuotes } from "../../handlers/list-xero-quotes.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatQuote } from "../../helpers/format-quote.js";
 
 const ListQuotesTool = CreateXeroTool(
   "list-quotes",
-  `List all quotes in Xero. 
-  Ask the user if they want to see quotes for a specific contact before running. 
-  Ask the user if they want the next page of quotes after running this tool if 10 quotes are returned. 
-  If they do, call this tool again with the page number and the contact provided in the previous call.`,
+  `List quotes in Xero, including each quote's line items.
+Ask the user if they want quotes for a specific contact before running.
+Ask the user if they want the next page after running this tool if 10 quotes are returned.
+If they do, call this tool again with the next page number and the same contact or quote number.
+When creating an invoice from a quote, pass each listed line item to create-invoice as its own line. Do not combine them into one line. Use get-quote for a single quote if you only have the ID.`,
   {
     page: z.number(),
     contactId: z.string().optional(),
@@ -36,38 +38,7 @@ const ListQuotesTool = CreateXeroTool(
         },
         ...(quotes?.map((quote) => ({
           type: "text" as const,
-          text: [
-            `Quote ID: ${quote.quoteID}`,
-            `Quote Number: ${quote.quoteNumber}`,
-            quote.reference ? `Reference: ${quote.reference}` : null,
-            `Status: ${quote.status || "Unknown"}`,
-            quote.contact
-              ? `Contact: ${quote.contact.name} (${quote.contact.contactID})`
-              : null,
-            quote.dateString ? `Quote Date: ${quote.dateString}` : null,
-            quote.expiryDateString
-              ? `Expiry Date: ${quote.expiryDateString}`
-              : null,
-            quote.title ? `Title: ${quote.title}` : null,
-            quote.summary ? `Summary: ${quote.summary}` : null,
-            quote.terms ? `Terms: ${quote.terms}` : null,
-            quote.lineAmountTypes
-              ? `Line Amount Types: ${quote.lineAmountTypes}`
-              : null,
-            quote.subTotal ? `Sub Total: ${quote.subTotal}` : null,
-            quote.totalTax ? `Total Tax: ${quote.totalTax}` : null,
-            `Total: ${quote.total || 0}`,
-            quote.totalDiscount
-              ? `Total Discount: ${quote.totalDiscount}`
-              : null,
-            quote.currencyCode ? `Currency: ${quote.currencyCode}` : null,
-            quote.currencyRate ? `Currency Rate: ${quote.currencyRate}` : null,
-            quote.updatedDateUTC
-              ? `Last Updated: ${quote.updatedDateUTC}`
-              : null,
-          ]
-            .filter(Boolean)
-            .join("\n"),
+          text: formatQuote(quote),
         })) || []),
       ],
     };

--- a/src/tools/tool-factory.test.ts
+++ b/src/tools/tool-factory.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { GetTools } from "./get/index.js";
+import { ListTools } from "./list/index.js";
+
+describe("quote tools are registered", () => {
+  it("includes list-quotes and get-quote", () => {
+    const names = [...ListTools, ...GetTools].map((tool) => tool().name);
+
+    expect(names).toEqual(
+      expect.arrayContaining(["list-quotes", "get-quote"]),
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    setupFiles: ["src/helpers/__tests__/vitest-setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

`list-quotes` already received `LineItems` from Xero (the list endpoint includes them when `page` is set) but never printed them. Models then created invoices from a quote by collapsing every line into one.

Closes #147.

### Changes
- `list-quotes` now prints each line item (description, quantity, unit amount, account, tax, item code, tracking)
- New `get-quote` tool fetches one quote by ID or quote number, including line items and a Xero deep link
- `create-invoice` tells the model to pass each quote line through as its own invoice line

Tracking and item objects are formatted as names, not `[object Object]`.

## Validation
- `npm test` — 27 passing
- `npx tsc --noEmit`
- `npm run lint`