### PR TITLE
feat: add bank, budget, and executive summary report tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Custom connections require different scopes depending on when they were created.
 > **Note:** The MCP server automatically tries V1 scopes first and falls back to V2 if needed.
 > 
 > You can override these by setting the `XERO_SCOPES` environment variable to a space-separated list of scopes.
+>
+> `list-bank-summary`, `list-budget-summary`, and `list-executive-summary` need `accounting.reports.read` on older apps, or `accounting.reports.banksummary.read` / `accounting.reports.budgetsummary.read` / `accounting.reports.executivesummary.read` on granular-scope apps. Those granular scopes are not in the default V2 list — add them via `XERO_SCOPES` (and on the Custom Connection) if you use them.
 
 ##### Integrating the MCP server with Claude Desktop
 
@@ -149,6 +151,9 @@ payroll.timesheets
 - `list-tax-rates`: Retrieve a list of tax rates
 - `list-payments`: Retrieve a list of payments
 - `list-trial-balance`: Retrieve a trial balance report
+- `list-bank-summary`: Retrieve the Bank Summary report
+- `list-budget-summary`: Retrieve the Budget Summary report
+- `list-executive-summary`: Retrieve the Executive Summary report
 - `list-bank-transactions`: Retrieve a list of bank account transactions
 - `list-payroll-employees`: Retrieve a list of Payroll Employees
 - `list-report-balance-sheet`: Retrieve a balance sheet report

--- a/src/handlers/__tests__/mock-xero-client.ts
+++ b/src/handlers/__tests__/mock-xero-client.ts
@@ -1,0 +1,21 @@
+import { vi } from "vitest";
+
+export const mockAccountingApi = {
+  getReportBankSummary: vi.fn(),
+  getReportBudgetSummary: vi.fn(),
+  getReportExecutiveSummary: vi.fn(),
+};
+
+export const mockXeroClient = {
+  authenticate: vi.fn().mockResolvedValue(undefined),
+  tenantId: "tenant-1",
+  accountingApi: mockAccountingApi,
+};
+
+export function resetXeroClientMocks() {
+  mockXeroClient.authenticate.mockClear();
+  mockXeroClient.authenticate.mockResolvedValue(undefined);
+  for (const fn of Object.values(mockAccountingApi)) {
+    fn.mockReset();
+  }
+}

--- a/src/handlers/list-xero-bank-summary.handler.test.ts
+++ b/src/handlers/list-xero-bank-summary.handler.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { listXeroBankSummary } from "./list-xero-bank-summary.handler.js";
+
+const report = {
+  reportName: "Bank Summary",
+  reportDate: "1 February 2026 to 28 February 2026",
+  rows: [{ rowType: "Header" }],
+};
+
+describe("listXeroBankSummary", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("fetches the bank summary with no date filters", async () => {
+    mockAccountingApi.getReportBankSummary.mockResolvedValue({
+      body: { reports: [report] },
+    });
+
+    const result = await listXeroBankSummary();
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toEqual(report);
+    expect(mockXeroClient.authenticate).toHaveBeenCalledOnce();
+    expect(mockAccountingApi.getReportBankSummary).toHaveBeenCalledWith(
+      "tenant-1",
+      undefined,
+      undefined,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+  });
+
+  it("forwards fromDate and toDate", async () => {
+    mockAccountingApi.getReportBankSummary.mockResolvedValue({
+      body: { reports: [report] },
+    });
+
+    await listXeroBankSummary({
+      fromDate: "2026-02-01",
+      toDate: "2026-02-28",
+    });
+
+    expect(mockAccountingApi.getReportBankSummary).toHaveBeenCalledWith(
+      "tenant-1",
+      "2026-02-01",
+      "2026-02-28",
+      expect.anything(),
+    );
+  });
+
+  it("returns an error when Xero omits the report", async () => {
+    mockAccountingApi.getReportBankSummary.mockResolvedValue({ body: {} });
+
+    const result = await listXeroBankSummary();
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Failed to fetch bank summary data from Xero.",
+    });
+  });
+
+  it("returns a formatted error when the report call fails", async () => {
+    mockAccountingApi.getReportBankSummary.mockRejectedValue(
+      new Error("insufficient_scope"),
+    );
+
+    const result = await listXeroBankSummary();
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "insufficient_scope",
+    });
+  });
+});

--- a/src/handlers/list-xero-bank-summary.handler.ts
+++ b/src/handlers/list-xero-bank-summary.handler.ts
@@ -1,0 +1,57 @@
+import { ReportWithRow } from "xero-node";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface ListBankSummaryParams {
+  fromDate?: string;
+  toDate?: string;
+}
+
+async function fetchBankSummary(
+  params: ListBankSummaryParams,
+): Promise<ReportWithRow | null> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getReportBankSummary(
+    xeroClient.tenantId,
+    params.fromDate,
+    params.toDate,
+    getClientHeaders(),
+  );
+
+  return response.body.reports?.[0] ?? null;
+}
+
+/**
+ * Bank summary report from Xero (statement opening/closing balances by bank account).
+ */
+export async function listXeroBankSummary(
+  params: ListBankSummaryParams = {},
+): Promise<XeroClientResponse<ReportWithRow>> {
+  try {
+    const report = await fetchBankSummary(params);
+
+    if (!report) {
+      return {
+        result: null,
+        isError: true,
+        error: "Failed to fetch bank summary data from Xero.",
+      };
+    }
+
+    return {
+      result: report,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-budget-summary.handler.test.ts
+++ b/src/handlers/list-xero-budget-summary.handler.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { listXeroBudgetSummary } from "./list-xero-budget-summary.handler.js";
+
+const report = {
+  reportName: "Budget Summary",
+  reportDate: "31 March 2026",
+  rows: [{ rowType: "Section" }],
+};
+
+describe("listXeroBudgetSummary", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("maps MONTH/QUARTER/YEAR timeframes to Xero period sizes", async () => {
+    mockAccountingApi.getReportBudgetSummary.mockResolvedValue({
+      body: { reports: [report] },
+    });
+
+    await listXeroBudgetSummary({
+      date: "2026-03-31",
+      periods: 3,
+      timeframe: "QUARTER",
+    });
+
+    expect(mockAccountingApi.getReportBudgetSummary).toHaveBeenCalledWith(
+      "tenant-1",
+      "2026-03-31",
+      3,
+      3,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+
+    mockAccountingApi.getReportBudgetSummary.mockClear();
+    await listXeroBudgetSummary({ timeframe: "MONTH" });
+    expect(mockAccountingApi.getReportBudgetSummary.mock.calls[0][3]).toBe(1);
+
+    mockAccountingApi.getReportBudgetSummary.mockClear();
+    await listXeroBudgetSummary({ timeframe: "YEAR" });
+    expect(mockAccountingApi.getReportBudgetSummary.mock.calls[0][3]).toBe(12);
+  });
+
+  it("returns the report payload", async () => {
+    mockAccountingApi.getReportBudgetSummary.mockResolvedValue({
+      body: { reports: [report] },
+    });
+
+    const result = await listXeroBudgetSummary();
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toEqual(report);
+  });
+
+  it("returns an error when Xero omits the report", async () => {
+    mockAccountingApi.getReportBudgetSummary.mockResolvedValue({
+      body: { reports: [] },
+    });
+
+    const result = await listXeroBudgetSummary();
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Failed to fetch budget summary data from Xero.",
+    });
+  });
+
+  it("returns a formatted error when the report call fails", async () => {
+    mockAccountingApi.getReportBudgetSummary.mockRejectedValue(
+      new Error("not authorised"),
+    );
+
+    const result = await listXeroBudgetSummary();
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "not authorised",
+    });
+  });
+});

--- a/src/handlers/list-xero-budget-summary.handler.ts
+++ b/src/handlers/list-xero-budget-summary.handler.ts
@@ -1,0 +1,67 @@
+import { ReportWithRow } from "xero-node";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export type BudgetTimeframe = "MONTH" | "QUARTER" | "YEAR";
+
+const BUDGET_TIMEFRAME: Record<BudgetTimeframe, number> = {
+  MONTH: 1,
+  QUARTER: 3,
+  YEAR: 12,
+};
+
+export interface ListBudgetSummaryParams {
+  date?: string;
+  periods?: number;
+  timeframe?: BudgetTimeframe;
+}
+
+async function fetchBudgetSummary(
+  params: ListBudgetSummaryParams,
+): Promise<ReportWithRow | null> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getReportBudgetSummary(
+    xeroClient.tenantId,
+    params.date,
+    params.periods,
+    params.timeframe ? BUDGET_TIMEFRAME[params.timeframe] : undefined,
+    getClientHeaders(),
+  );
+
+  return response.body.reports?.[0] ?? null;
+}
+
+/**
+ * Budget summary report from Xero (budget vs actual by period).
+ */
+export async function listXeroBudgetSummary(
+  params: ListBudgetSummaryParams = {},
+): Promise<XeroClientResponse<ReportWithRow>> {
+  try {
+    const report = await fetchBudgetSummary(params);
+
+    if (!report) {
+      return {
+        result: null,
+        isError: true,
+        error: "Failed to fetch budget summary data from Xero.",
+      };
+    }
+
+    return {
+      result: report,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-executive-summary.handler.test.ts
+++ b/src/handlers/list-xero-executive-summary.handler.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAccountingApi,
+  mockXeroClient,
+  resetXeroClientMocks,
+} from "./__tests__/mock-xero-client.js";
+
+vi.mock("../clients/xero-client.js", () => ({
+  xeroClient: mockXeroClient,
+}));
+
+import { listXeroExecutiveSummary } from "./list-xero-executive-summary.handler.js";
+
+const report = {
+  reportName: "Executive Summary",
+  reportDate: "31 March 2026",
+  rows: [{ rowType: "Section" }],
+};
+
+describe("listXeroExecutiveSummary", () => {
+  beforeEach(() => {
+    resetXeroClientMocks();
+  });
+
+  it("fetches the executive summary for an optional date", async () => {
+    mockAccountingApi.getReportExecutiveSummary.mockResolvedValue({
+      body: { reports: [report] },
+    });
+
+    const result = await listXeroExecutiveSummary({ date: "2026-03-31" });
+
+    expect(result.isError).toBe(false);
+    if (result.isError) return;
+    expect(result.result).toEqual(report);
+    expect(mockXeroClient.authenticate).toHaveBeenCalledOnce();
+    expect(mockAccountingApi.getReportExecutiveSummary).toHaveBeenCalledWith(
+      "tenant-1",
+      "2026-03-31",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining("xero-mcp-server"),
+        }),
+      }),
+    );
+  });
+
+  it("returns an error when Xero omits the report", async () => {
+    mockAccountingApi.getReportExecutiveSummary.mockResolvedValue({ body: {} });
+
+    const result = await listXeroExecutiveSummary();
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Failed to fetch executive summary data from Xero.",
+    });
+  });
+
+  it("returns a formatted error when the report call fails", async () => {
+    mockAccountingApi.getReportExecutiveSummary.mockRejectedValue(
+      new Error("insufficient_scope"),
+    );
+
+    const result = await listXeroExecutiveSummary();
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "insufficient_scope",
+    });
+  });
+});

--- a/src/handlers/list-xero-executive-summary.handler.ts
+++ b/src/handlers/list-xero-executive-summary.handler.ts
@@ -1,0 +1,55 @@
+import { ReportWithRow } from "xero-node";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+export interface ListExecutiveSummaryParams {
+  date?: string;
+}
+
+async function fetchExecutiveSummary(
+  params: ListExecutiveSummaryParams,
+): Promise<ReportWithRow | null> {
+  await xeroClient.authenticate();
+
+  const response = await xeroClient.accountingApi.getReportExecutiveSummary(
+    xeroClient.tenantId,
+    params.date,
+    getClientHeaders(),
+  );
+
+  return response.body.reports?.[0] ?? null;
+}
+
+/**
+ * Executive summary report from Xero (cash, P&L, and balance-sheet highlights).
+ */
+export async function listXeroExecutiveSummary(
+  params: ListExecutiveSummaryParams = {},
+): Promise<XeroClientResponse<ReportWithRow>> {
+  try {
+    const report = await fetchExecutiveSummary(params);
+
+    if (!report) {
+      return {
+        result: null,
+        isError: true,
+        error: "Failed to fetch executive summary data from Xero.",
+      };
+    }
+
+    return {
+      result: report,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/helpers/__tests__/vitest-setup.ts
+++ b/src/helpers/__tests__/vitest-setup.ts
@@ -1,0 +1,2 @@
+process.env.XERO_CLIENT_ID ??= "test-client-id";
+process.env.XERO_CLIENT_SECRET ??= "test-client-secret";

--- a/src/helpers/format-report.ts
+++ b/src/helpers/format-report.ts
@@ -1,0 +1,29 @@
+import { ReportWithRow } from "xero-node";
+
+export function formatReportContent(
+  title: string,
+  report: ReportWithRow,
+): { type: "text"; text: string }[] {
+  return [
+    {
+      type: "text" as const,
+      text: `${title}: ${report.reportName ?? "Unnamed"}`,
+    },
+    {
+      type: "text" as const,
+      text: `Date: ${report.reportDate ?? "Not specified"}`,
+    },
+    {
+      type: "text" as const,
+      text: `Updated At: ${
+        report.updatedDateUTC
+          ? report.updatedDateUTC.toISOString()
+          : "Unknown"
+      }`,
+    },
+    {
+      type: "text" as const,
+      text: JSON.stringify(report.rows, null, 2),
+    },
+  ];
+}

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -2,9 +2,12 @@ import ListAccountsTool from "./list-accounts.tool.js";
 import ListAgedPayablesByContact from "./list-aged-payables-by-contact.tool.js";
 import ListAgedReceivablesByContact
   from "./list-aged-receivables-by-contact.tool.js";
+import ListBankSummaryTool from "./list-bank-summary.tool.js";
 import ListBankTransactionsTool from "./list-bank-transactions.tool.js";
+import ListBudgetSummaryTool from "./list-budget-summary.tool.js";
 import ListContactsTool from "./list-contacts.tool.js";
 import ListCreditNotesTool from "./list-credit-notes.tool.js";
+import ListExecutiveSummaryTool from "./list-executive-summary.tool.js";
 import ListInvoicesTool from "./list-invoices.tool.js";
 import ListItemsTool from "./list-items.tool.js";
 import ListManualJournalsTool from "./list-manual-journals.tool.js";
@@ -41,6 +44,9 @@ export const ListTools = [
   ListTrialBalanceTool,
   ListPaymentsTool,
   ListProfitAndLossTool,
+  ListBankSummaryTool,
+  ListBudgetSummaryTool,
+  ListExecutiveSummaryTool,
   ListBankTransactionsTool,
   ListPayrollEmployeesTool,
   ListReportBalanceSheetTool,

--- a/src/tools/list/list-bank-summary.tool.ts
+++ b/src/tools/list/list-bank-summary.tool.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+import { listXeroBankSummary } from "../../handlers/list-xero-bank-summary.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatReportContent } from "../../helpers/format-report.js";
+
+const ListBankSummaryTool = CreateXeroTool(
+  "list-bank-summary",
+  `List the Bank Summary report from Xero. Shows opening balance, cash received, cash spent, and closing balance for each bank account in a date range.
+Needs accounting.reports.read (legacy) or accounting.reports.banksummary.read (granular). Those scopes are not added to the default Custom Connection list — set XERO_SCOPES if your app uses granular report scopes.`,
+  {
+    fromDate: z
+      .string()
+      .optional()
+      .describe("Optional start date in YYYY-MM-DD format"),
+    toDate: z
+      .string()
+      .optional()
+      .describe("Optional end date in YYYY-MM-DD format"),
+  },
+  async ({ fromDate, toDate }) => {
+    const response = await listXeroBankSummary({ fromDate, toDate });
+
+    if (response.error !== null) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing bank summary: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: formatReportContent("Bank Summary Report", response.result),
+    };
+  },
+);
+
+export default ListBankSummaryTool;

--- a/src/tools/list/list-budget-summary.tool.ts
+++ b/src/tools/list/list-budget-summary.tool.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+import { listXeroBudgetSummary } from "../../handlers/list-xero-budget-summary.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatReportContent } from "../../helpers/format-report.js";
+
+const ListBudgetSummaryTool = CreateXeroTool(
+  "list-budget-summary",
+  `List the Budget Summary report from Xero. Compares budget vs actual across periods.
+Needs accounting.reports.read (legacy) or accounting.reports.budgetsummary.read (granular). Those scopes are not added to the default Custom Connection list — set XERO_SCOPES if your app uses granular report scopes.`,
+  {
+    date: z
+      .string()
+      .optional()
+      .describe("Optional as-at date in YYYY-MM-DD format"),
+    periods: z
+      .number()
+      .int()
+      .min(1)
+      .max(12)
+      .optional()
+      .describe("Optional number of periods to compare (1-12)"),
+    timeframe: z
+      .enum(["MONTH", "QUARTER", "YEAR"])
+      .optional()
+      .describe("Optional period size to compare (MONTH, QUARTER, YEAR)"),
+  },
+  async ({ date, periods, timeframe }) => {
+    const response = await listXeroBudgetSummary({ date, periods, timeframe });
+
+    if (response.error !== null) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing budget summary: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: formatReportContent("Budget Summary Report", response.result),
+    };
+  },
+);
+
+export default ListBudgetSummaryTool;

--- a/src/tools/list/list-executive-summary.tool.ts
+++ b/src/tools/list/list-executive-summary.tool.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+import { listXeroExecutiveSummary } from "../../handlers/list-xero-executive-summary.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { formatReportContent } from "../../helpers/format-report.js";
+
+const ListExecutiveSummaryTool = CreateXeroTool(
+  "list-executive-summary",
+  `List the Executive Summary report from Xero. A one-page snapshot of cash, profit and loss, and balance-sheet highlights as at a date.
+Needs accounting.reports.read (legacy) or accounting.reports.executivesummary.read (granular). Those scopes are not added to the default Custom Connection list — set XERO_SCOPES if your app uses granular report scopes.`,
+  {
+    date: z
+      .string()
+      .optional()
+      .describe("Optional as-at date in YYYY-MM-DD format"),
+  },
+  async ({ date }) => {
+    const response = await listXeroExecutiveSummary({ date });
+
+    if (response.error !== null) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing executive summary: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: formatReportContent("Executive Summary Report", response.result),
+    };
+  },
+);
+
+export default ListExecutiveSummaryTool;

--- a/src/tools/tool-factory.test.ts
+++ b/src/tools/tool-factory.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { ListTools } from "./list/index.js";
+
+describe("report summary tools are registered", () => {
+  it("includes bank, budget, and executive summary reports", () => {
+    const names = ListTools.map((tool) => tool().name);
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "list-bank-summary",
+        "list-budget-summary",
+        "list-executive-summary",
+      ]),
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    setupFiles: ["src/helpers/__tests__/vitest-setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Adds the Accounting API reports that `xero-node` already exposes and that #183 called out as missing from a quarterly pack.

### Tools
- `list-bank-summary` — opening/cash in/cash out/closing by bank account (`fromDate`, `toDate`)
- `list-budget-summary` — budget vs actual (`date`, `periods` 1–12, `timeframe` MONTH/QUARTER/YEAR)
- `list-executive-summary` — cash / P&L / balance-sheet snapshot (`date`)

These match the existing P&L / trial balance / balance sheet tools.

**Not in this PR:** General Ledger, GST/BAS, Cash Summary, and payroll activity reports. Those endpoints are not in `xero-node` v13 (`getReport*`). Attachments, fixed assets, and invoice approve/void already have other open PRs.

### Scopes
Default Custom Connection scopes are unchanged (same lesson as journals: requesting an unapproved granular scope fails token exchange with `invalid_scope`).

- Legacy apps: already covered by `accounting.reports.read`
- Granular apps: add `accounting.reports.banksummary.read`, `accounting.reports.budgetsummary.read`, and/or `accounting.reports.executivesummary.read` via `XERO_SCOPES` and on the Custom Connection

## Validation
- `npm test` — 26 passing
- `npx tsc --noEmit`
- `npm run lint`