### PR TITLE
feat: gate list-trial-balance on exact movement and YTD integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ payroll.timesheets
 - `list-quotes`: Retrieve a list of quotes
 - `list-tax-rates`: Retrieve a list of tax rates
 - `list-payments`: Retrieve a list of payments
-- `list-trial-balance`: Retrieve a trial balance report
+- `list-trial-balance`: Retrieve a trial balance report. Debit/Credit are month movement; YTD Debit/YTD Credit are as-at balances. Both pairs must balance exactly or the tool returns Integrity BLOCKED and withholds the row pack. PASS is not close approval.
 - `list-bank-transactions`: Retrieve a list of bank account transactions
 - `list-payroll-employees`: Retrieve a list of Payroll Employees
 - `list-report-balance-sheet`: Retrieve a balance sheet report

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,13 +31,39 @@
         "vitest": "^4.1.5"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -600,6 +626,40 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
@@ -697,7 +757,6 @@
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -748,7 +807,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1092,7 +1150,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1593,7 +1650,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1837,7 +1893,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2284,7 +2339,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3187,7 +3241,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3816,7 +3869,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3890,7 +3942,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4159,7 +4210,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/helpers/__tests__/trial-balance-integrity.test.ts
+++ b/src/helpers/__tests__/trial-balance-integrity.test.ts
@@ -71,6 +71,20 @@ describe("parseAmount", () => {
 });
 
 describe("assessTrialBalanceIntegrity", () => {
+  it.each([
+    { rows: [headerRow(["Anything"])] },
+    { rows: [headerRow()] },
+    report([]),
+    { rows: [headerRow(), accountRow("Cash", "1", "", "1", "")] },
+    {
+      rows: [headerRow(), { rowType: "Section", rows: [
+        { ...accountRow("Cash", "1", "", "1", ""), rowType: "Unexpected" },
+      ] }],
+    },
+  ])("BLOCKs incomplete or unsupported report shapes: %j", (payload) => {
+    expect(assessTrialBalanceIntegrity(payload).status).toBe("BLOCKED");
+  });
+
   it("PASSes 0.1 + 0.2 against 0.3 (no IEEE float)", () => {
     const result = assessTrialBalanceIntegrity(
       report([

--- a/src/helpers/__tests__/trial-balance-integrity.test.ts
+++ b/src/helpers/__tests__/trial-balance-integrity.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  assessTrialBalanceIntegrity,
+  formatAmount,
+  formatIntegrityMessage,
+  parseAmount,
+  type ReportRow,
+  type TrialBalanceReport,
+} from "../trial-balance-integrity.js";
+
+const HEADER = ["Account", "Debit", "Credit", "YTD Debit", "YTD Credit"] as const;
+
+function headerRow(titles: readonly string[] = HEADER): ReportRow {
+  return {
+    rowType: "Header",
+    cells: titles.map((title) => ({ value: title })),
+  };
+}
+
+function accountRow(
+  label: string,
+  debit: string,
+  credit: string,
+  ytdDebit: string,
+  ytdCredit: string,
+  index = 1,
+): ReportRow {
+  return {
+    rowType: "Row",
+    cells: [
+      {
+        value: label,
+        attributes: [{ id: "account", value: `00000000-0000-0000-0000-${String(index).padStart(12, "0")}` }],
+      },
+      { value: debit },
+      { value: credit },
+      { value: ytdDebit },
+      { value: ytdCredit },
+    ],
+  };
+}
+
+function report(accounts: Array<[string, string, string, string, string]>, titles: readonly string[] = HEADER): TrialBalanceReport {
+  const rows: ReportRow[] = [headerRow(titles)];
+  const data = accounts.map((tuple, i) => accountRow(tuple[0], tuple[1], tuple[2], tuple[3], tuple[4], i + 1));
+  data.push({
+    rowType: "SummaryRow",
+    cells: [{ value: "Total" }, { value: "999" }, { value: "999" }, { value: "999" }, { value: "999" }],
+  });
+  rows.push({ rowType: "Section", title: "Revenue", rows: data });
+  return { reportName: "Trial Balance", reportDate: "30 June 2026", rows };
+}
+
+describe("parseAmount", () => {
+  it("treats blank and missing as zero", () => {
+    expect(parseAmount("")).toEqual({ n: 0n, scale: 0 });
+    expect(parseAmount(null)).toEqual({ n: 0n, scale: 0 });
+    expect(parseAmount("   ")).toEqual({ n: 0n, scale: 0 });
+  });
+
+  it("parses exact decimals without float", () => {
+    expect(parseAmount("0.10")).toEqual({ n: 10n, scale: 2 });
+    expect(parseAmount("0.20")).toEqual({ n: 20n, scale: 2 });
+    expect(formatAmount({ n: 30n, scale: 2 })).toBe("0.30");
+  });
+
+  it("refuses non-amounts", () => {
+    const result = parseAmount("n/a");
+    expect(result).toEqual(expect.objectContaining({ error: expect.stringContaining("not an amount") }));
+  });
+});
+
+describe("assessTrialBalanceIntegrity", () => {
+  it("PASSes 0.1 + 0.2 against 0.3 (no IEEE float)", () => {
+    const result = assessTrialBalanceIntegrity(
+      report([
+        ["Cash (090)", "0.1", "", "0.1", ""],
+        ["Receivable (100)", "0.2", "", "0.2", ""],
+        ["Sales (200)", "", "0.3", "", "0.3"],
+      ]),
+    );
+    expect(result.status).toBe("PASS");
+    if (result.status !== "PASS") return;
+    expect(result.movementDebits).toBe("0.30");
+    expect(result.movementCredits).toBe("0.30");
+  });
+
+  it("PASSes when movement and YTD both balance, ignoring SummaryRow", () => {
+    const result = assessTrialBalanceIntegrity(
+      report([
+        ["Sales (200)", "", "100.00", "", "400.00"],
+        ["Cash (090)", "100.00", "", "400.00", ""],
+      ]),
+    );
+    expect(result.status).toBe("PASS");
+    if (result.status !== "PASS") return;
+    expect(result.accountRows).toBe(2);
+    expect(result.movementDebits).toBe("100.00");
+    expect(result.movementCredits).toBe("100.00");
+    expect(result.ytdDebits).toBe("400.00");
+    expect(result.ytdCredits).toBe("400.00");
+    expect(formatIntegrityMessage(result)).toContain("PASS is not close approval");
+  });
+
+  it("BLOCKs when movement is unbalanced even if YTD balances", () => {
+    const result = assessTrialBalanceIntegrity(
+      report([
+        ["Sales (200)", "", "100.00", "", "400.00"],
+        ["Cash (090)", "90.00", "", "400.00", ""],
+      ]),
+    );
+    expect(result.status).toBe("BLOCKED");
+    if (result.status !== "BLOCKED") return;
+    expect(result.reason).toContain("movement");
+    expect(result.reason).toContain("Nothing returned as a usable pack");
+  });
+
+  it("BLOCKs when YTD is unbalanced even if movement balances", () => {
+    const result = assessTrialBalanceIntegrity(
+      report([
+        ["Sales (200)", "", "50.00", "", "400.00"],
+        ["Cash (090)", "50.00", "", "399.99", ""],
+      ]),
+    );
+    expect(result.status).toBe("BLOCKED");
+    if (result.status !== "BLOCKED") return;
+    expect(result.reason).toContain("YTD");
+  });
+
+  it("BLOCKs a missing expected column", () => {
+    const result = assessTrialBalanceIntegrity(
+      report([["Cash (090)", "1", "1", "1", "1"]], ["Account", "Debit", "Credit", "YTD Debit"]),
+    );
+    expect(result.status).toBe("BLOCKED");
+    if (result.status !== "BLOCKED") return;
+    expect(result.reason).toContain("YTD Credit");
+  });
+
+  it("BLOCKs a row whose cell count does not match the header", () => {
+    const payload: TrialBalanceReport = {
+      rows: [
+        headerRow(),
+        {
+          rowType: "Section",
+          title: "Assets",
+          rows: [
+            {
+              rowType: "Row",
+              cells: [{ value: "Cash (090)" }, { value: "1.00" }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = assessTrialBalanceIntegrity(payload);
+    expect(result.status).toBe("BLOCKED");
+    if (result.status !== "BLOCKED") return;
+    expect(result.reason).toContain("2 cells under 5 header columns");
+  });
+
+  it("BLOCKs a missing report", () => {
+    expect(assessTrialBalanceIntegrity(null).status).toBe("BLOCKED");
+  });
+});

--- a/src/helpers/trial-balance-integrity.ts
+++ b/src/helpers/trial-balance-integrity.ts
@@ -1,0 +1,364 @@
+/**
+ * Exact trial-balance integrity for Xero Reports/TrialBalance.
+ *
+ * Debit/Credit cells are the current-month movement; YTD Debit/YTD Credit are
+ * the as-at balances. Both pairs must total exactly. Totals are recomputed
+ * from account rows; SummaryRow values are ignored. Arithmetic is decimal
+ * (scaled BigInt), never IEEE float.
+ *
+ * PASS means the pairs balance. BLOCKED means the report is truncated,
+ * misparsed, or a shape the helper does not recognise. READY is not a
+ * status here: a balanced report is still for human review.
+ */
+
+const MAX_EXPONENT = 30;
+const REQUIRED_COLUMNS = ["Account", "Debit", "Credit", "YTD Debit", "YTD Credit"] as const;
+
+export type ReportCell = {
+  value?: string | number | null;
+  attributes?: Array<{ id?: string; value?: string }>;
+};
+
+export type ReportRow = {
+  // xero-node's published .d.ts types RowType as a numeric enum; the generated
+  // JS (and the JSON the API sends) is string-valued. Keep this structural.
+  rowType?: unknown;
+  title?: string;
+  cells?: ReportCell[];
+  rows?: ReportRow[];
+};
+
+export type TrialBalanceReport = {
+  reportName?: string;
+  reportDate?: string;
+  updatedDateUTC?: Date | string;
+  rows?: ReportRow[];
+};
+
+export type Amount = { n: bigint; scale: number };
+
+export type IntegrityPass = {
+  status: "PASS";
+  accountRows: number;
+  movementDebits: string;
+  movementCredits: string;
+  ytdDebits: string;
+  ytdCredits: string;
+};
+
+export type IntegrityBlocked = {
+  status: "BLOCKED";
+  reason: string;
+  accountRows?: number;
+  movementDebits?: string;
+  movementCredits?: string;
+  ytdDebits?: string;
+  ytdCredits?: string;
+};
+
+export type IntegrityResult = IntegrityPass | IntegrityBlocked;
+
+export function parseAmount(value: unknown): Amount | { error: string } {
+  if (value == null) {
+    return { n: 0n, scale: 0 };
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return { error: "report cell is not an amount" };
+    }
+    return parseAmountString(String(value));
+  }
+  if (typeof value !== "string") {
+    return {
+      error: `report cell Value is not text or a number (${typeof value})`,
+    };
+  }
+  const text = value.trim();
+  if (text === "") {
+    return { n: 0n, scale: 0 };
+  }
+  return parseAmountString(text);
+}
+
+function parseAmountString(text: string): Amount | { error: string } {
+  const match = text.match(/^([+-])?(\d+)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/);
+  if (!match) {
+    return { error: `report cell "${shown(text)}" is not an amount` };
+  }
+  const sign = match[1] === "-" ? -1n : 1n;
+  const whole = match[2];
+  const frac = match[3] ?? "";
+  const exp = match[4] == null ? 0 : Number(match[4]);
+  const digits = whole + frac;
+  const scale = frac.length - exp;
+  if (digits.replace(/0/g, "").length === 0) {
+    return { n: 0n, scale: 0 };
+  }
+  const exponent = digits.length - 1 - scale;
+  if (exponent > MAX_EXPONENT) {
+    return {
+      error: `report cell "${shown(text)}" is ${exponent + 1} digits long, which is not a ledger balance`,
+    };
+  }
+  if (exponent < -MAX_EXPONENT) {
+    return {
+      error: `report cell "${shown(text)}" is smaller than any ledger balance`,
+    };
+  }
+  let n = BigInt(digits);
+  if (sign < 0n) n = -n;
+  return { n, scale };
+}
+
+export function addAmounts(a: Amount, b: Amount): Amount {
+  if (a.scale === b.scale) {
+    return { n: a.n + b.n, scale: a.scale };
+  }
+  if (a.scale > b.scale) {
+    return { n: a.n + b.n * 10n ** BigInt(a.scale - b.scale), scale: a.scale };
+  }
+  return { n: b.n + a.n * 10n ** BigInt(b.scale - a.scale), scale: b.scale };
+}
+
+export function amountsEqual(a: Amount, b: Amount): boolean {
+  const diff = addAmounts(a, { n: -b.n, scale: b.scale });
+  return diff.n === 0n;
+}
+
+export function formatAmount(amount: Amount): string {
+  if (amount.n === 0n) {
+    return "0.00";
+  }
+  const negative = amount.n < 0n;
+  const digits = (negative ? -amount.n : amount.n).toString();
+  if (amount.scale <= 0) {
+    const zeros = "0".repeat(-amount.scale);
+    const whole = digits + zeros;
+    return `${negative ? "-" : ""}${whole}.00`;
+  }
+  const padded = digits.padStart(amount.scale + 1, "0");
+  const split = padded.length - amount.scale;
+  let frac = padded.slice(split);
+  if (frac.length < 2) {
+    frac = frac.padEnd(2, "0");
+  }
+  return `${negative ? "-" : ""}${padded.slice(0, split)}.${frac}`;
+}
+
+function shown(text: string): string {
+  return [...text].filter((ch) => ch >= " " && ch <= "~").join("").slice(0, 40);
+}
+
+function rowTypeName(row: ReportRow): string {
+  return typeof row.rowType === "string" ? row.rowType : "";
+}
+
+function cellText(cell: ReportCell | undefined, where: string): string | { error: string } {
+  if (!cell) {
+    return "";
+  }
+  const value = cell.value;
+  if (value == null) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return {
+    error: `report ${where} has a cell Value that is not text or a number`,
+  };
+}
+
+function objectList<T>(value: T[] | undefined, where: string, key: string): T[] | { error: string } {
+  if (value == null) {
+    return [];
+  }
+  if (!Array.isArray(value) || value.some((item) => item == null || typeof item !== "object")) {
+    return {
+      error: `report ${where} has a ${key} value that is not a list of objects`,
+    };
+  }
+  return value;
+}
+
+function headerTitles(header: ReportRow): string[] | { error: string } {
+  const cells = objectList(header.cells, "header", "cells");
+  if ("error" in cells) {
+    return cells;
+  }
+  const titles: string[] = [];
+  for (const cell of cells) {
+    const text = cellText(cell, "header");
+    if (typeof text !== "string") {
+      return text;
+    }
+    titles.push(text);
+  }
+  return titles;
+}
+
+type Totals = {
+  movementDebits: Amount;
+  movementCredits: Amount;
+  ytdDebits: Amount;
+  ytdCredits: Amount;
+  accountRows: number;
+};
+
+function emptyTotals(): Totals {
+  const zero: Amount = { n: 0n, scale: 0 };
+  return {
+    movementDebits: zero,
+    movementCredits: zero,
+    ytdDebits: zero,
+    ytdCredits: zero,
+    accountRows: 0,
+  };
+}
+
+function addCell(
+  totals: Totals,
+  field: keyof Omit<Totals, "accountRows">,
+  raw: unknown,
+): { error: string } | null {
+  const parsed = parseAmount(raw);
+  if ("error" in parsed) {
+    return parsed;
+  }
+  totals[field] = addAmounts(totals[field], parsed);
+  return null;
+}
+
+function flattenAndTotal(report: TrialBalanceReport): Totals | { error: string } {
+  const top = objectList(report.rows, "top level", "rows");
+  if ("error" in top) {
+    return top;
+  }
+
+  let titles: string[] | null = null;
+  const totals = emptyTotals();
+
+  for (const row of top) {
+    if (rowTypeName(row) === "Header") {
+      const header = headerTitles(row);
+      if ("error" in header) {
+        return header;
+      }
+      titles = header;
+      continue;
+    }
+    if (rowTypeName(row) !== "Section") {
+      continue;
+    }
+    const section = shown(row.title ?? "");
+    const where = `section "${section}"`;
+    const inner = objectList(row.rows, where, "rows");
+    if ("error" in inner) {
+      return inner;
+    }
+    if (!titles) {
+      return { error: "report has account rows before a Header, or is not a trial balance report" };
+    }
+    const headerTitlesNow: string[] = titles;
+    const missing = REQUIRED_COLUMNS.filter((name) => !headerTitlesNow.includes(name));
+    if (missing.length > 0) {
+      return {
+        error: `report is missing expected columns (${missing.join(", ")}). The API shape may have changed, or this is not a trial balance report`,
+      };
+    }
+    const debitIdx = headerTitlesNow.indexOf("Debit");
+    const creditIdx = headerTitlesNow.indexOf("Credit");
+    const ytdDebitIdx = headerTitlesNow.indexOf("YTD Debit");
+    const ytdCreditIdx = headerTitlesNow.indexOf("YTD Credit");
+
+    for (const child of inner) {
+      if (rowTypeName(child) !== "Row") {
+        continue;
+      }
+      const cells = objectList(child.cells, where, "cells");
+      if ("error" in cells) {
+        return cells;
+      }
+      if (cells.length !== headerTitlesNow.length) {
+        return {
+          error: `report ${where} has a row of ${cells.length} cells under ${headerTitlesNow.length} header columns. The API shape may have changed, or this is not a trial balance report`,
+        };
+      }
+      const values: string[] = [];
+      for (const cell of cells) {
+        const text = cellText(cell, where);
+        if (typeof text !== "string") {
+          return text;
+        }
+        values.push(text);
+      }
+      const debit = addCell(totals, "movementDebits", values[debitIdx]);
+      if (debit) return debit;
+      const credit = addCell(totals, "movementCredits", values[creditIdx]);
+      if (credit) return credit;
+      const ytdDebit = addCell(totals, "ytdDebits", values[ytdDebitIdx]);
+      if (ytdDebit) return ytdDebit;
+      const ytdCredit = addCell(totals, "ytdCredits", values[ytdCreditIdx]);
+      if (ytdCredit) return ytdCredit;
+      totals.accountRows += 1;
+    }
+  }
+
+  if (!titles) {
+    return { error: "report has no Header row. The API shape may have changed, or this is not a trial balance report" };
+  }
+  return totals;
+}
+
+export function assessTrialBalanceIntegrity(report: TrialBalanceReport | null | undefined): IntegrityResult {
+  if (!report) {
+    return { status: "BLOCKED", reason: "Failed to fetch trial balance data from Xero." };
+  }
+  const totals = flattenAndTotal(report);
+  if ("error" in totals) {
+    return { status: "BLOCKED", reason: totals.error };
+  }
+
+  const movementOk = amountsEqual(totals.movementDebits, totals.movementCredits);
+  const ytdOk = amountsEqual(totals.ytdDebits, totals.ytdCredits);
+  const snapshot = {
+    accountRows: totals.accountRows,
+    movementDebits: formatAmount(totals.movementDebits),
+    movementCredits: formatAmount(totals.movementCredits),
+    ytdDebits: formatAmount(totals.ytdDebits),
+    ytdCredits: formatAmount(totals.ytdCredits),
+  };
+
+  if (movementOk && ytdOk) {
+    return { status: "PASS", ...snapshot };
+  }
+
+  const parts: string[] = [];
+  if (!movementOk) {
+    parts.push(
+      `movement debits ${snapshot.movementDebits} != credits ${snapshot.movementCredits}`,
+    );
+  }
+  if (!ytdOk) {
+    parts.push(`YTD debits ${snapshot.ytdDebits} != credits ${snapshot.ytdCredits}`);
+  }
+  return {
+    status: "BLOCKED",
+    reason: `Nothing returned as a usable pack — ${parts.join("; ")}. Report likely truncated or misparsed.`,
+    ...snapshot,
+  };
+}
+
+export function formatIntegrityMessage(result: IntegrityResult): string {
+  if (result.status === "PASS") {
+    return (
+      `Integrity PASS: movement debits = credits = ${result.movementDebits}; ` +
+      `YTD = ${result.ytdDebits} (${result.accountRows} account rows). ` +
+      "PASS is not close approval."
+    );
+  }
+  return `Integrity BLOCKED: ${result.reason}`;
+}

--- a/src/helpers/trial-balance-integrity.ts
+++ b/src/helpers/trial-balance-integrity.ts
@@ -247,11 +247,17 @@ function flattenAndTotal(report: TrialBalanceReport): Totals | { error: string }
       if ("error" in header) {
         return header;
       }
+      const missing = REQUIRED_COLUMNS.filter((name) => !header.includes(name));
+      if (missing.length > 0) {
+        return {
+          error: `report is missing expected columns (${missing.join(", ")}). The API shape may have changed, or this is not a trial balance report`,
+        };
+      }
       titles = header;
       continue;
     }
     if (rowTypeName(row) !== "Section") {
-      continue;
+      return { error: `unsupported top-level row type: ${rowTypeName(row)}` };
     }
     const section = shown(row.title ?? "");
     const where = `section "${section}"`;
@@ -263,20 +269,17 @@ function flattenAndTotal(report: TrialBalanceReport): Totals | { error: string }
       return { error: "report has account rows before a Header, or is not a trial balance report" };
     }
     const headerTitlesNow: string[] = titles;
-    const missing = REQUIRED_COLUMNS.filter((name) => !headerTitlesNow.includes(name));
-    if (missing.length > 0) {
-      return {
-        error: `report is missing expected columns (${missing.join(", ")}). The API shape may have changed, or this is not a trial balance report`,
-      };
-    }
     const debitIdx = headerTitlesNow.indexOf("Debit");
     const creditIdx = headerTitlesNow.indexOf("Credit");
     const ytdDebitIdx = headerTitlesNow.indexOf("YTD Debit");
     const ytdCreditIdx = headerTitlesNow.indexOf("YTD Credit");
 
     for (const child of inner) {
-      if (rowTypeName(child) !== "Row") {
+      if (rowTypeName(child) === "SummaryRow") {
         continue;
+      }
+      if (rowTypeName(child) !== "Row") {
+        return { error: `unsupported row type in ${where}: ${rowTypeName(child)}` };
       }
       const cells = objectList(child.cells, where, "cells");
       if ("error" in cells) {
@@ -309,6 +312,9 @@ function flattenAndTotal(report: TrialBalanceReport): Totals | { error: string }
 
   if (!titles) {
     return { error: "report has no Header row. The API shape may have changed, or this is not a trial balance report" };
+  }
+  if (totals.accountRows === 0) {
+    return { error: "report has no account rows; trial balance integrity cannot be established" };
   }
   return totals;
 }

--- a/src/tools/list/list-trial-balance.tool.ts
+++ b/src/tools/list/list-trial-balance.tool.ts
@@ -1,10 +1,14 @@
 import { z } from "zod";
 import { listXeroTrialBalance } from "../../handlers/list-xero-trial-balance.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import {
+  assessTrialBalanceIntegrity,
+  formatIntegrityMessage,
+} from "../../helpers/trial-balance-integrity.js";
 
 const ListTrialBalanceTool = CreateXeroTool(
   "list-trial-balance",
-  "Lists trial balance in Xero. This provides a snapshot of the general ledger, showing debit and credit balances for each account.",
+  "Lists the Xero trial balance. Debit/Credit are the current-month movement; YTD Debit/YTD Credit are as-at balances. Both pairs must balance exactly or the tool returns Integrity BLOCKED and withholds the row pack. PASS is not close approval.",
   {
     date: z.string().optional().describe("Optional date in YYYY-MM-DD format"),
     paymentsOnly: z.boolean().optional().describe("Optional flag to include only accounts with payments"),
@@ -22,10 +26,26 @@ const ListTrialBalanceTool = CreateXeroTool(
       };
     }
 
-   const trialBalanceReport = response.result;
+    const trialBalanceReport = response.result;
+    const integrity = assessTrialBalanceIntegrity(trialBalanceReport);
+
+    if (integrity.status === "BLOCKED") {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: formatIntegrityMessage(integrity),
+          },
+        ],
+      };
+    }
 
     return {
       content: [
+        {
+          type: "text" as const,
+          text: formatIntegrityMessage(integrity),
+        },
         {
           type: "text" as const,
           text: `Trial Balance Report: ${trialBalanceReport?.reportName || "Unnamed"}`,


### PR DESCRIPTION
Adds an integrity gate to `list-trial-balance`. It recomputes current-month Debit/Credit and as-at YTD Debit/YTD Credit totals from account rows using scaled BigInt arithmetic. Both pairs must balance exactly. Summary totals are excluded from the calculation.

The gate validates required columns even when no Section follows the header, rejects unsupported row types and blocks reports with no account rows. Malformed or unbalanced reports return BLOCKED and withhold the JSON pack. PASS retains the existing report output and explicitly does not approve a close.

Verification, 10 September 2026:

- `npm test`: 29 tests passed, including five incomplete or unsupported report shapes and balanced controls.
- `npm run lint` and `npm run build` passed.
- `npm ci --ignore-scripts` passed after repairing missing optional test-tool dependency entries in `package-lock.json`. Direct dependencies are unchanged.

No hosted checks are currently reported on this PR. No live Xero request was made. An empty report is blocked because the helper cannot establish its integrity from zero account rows.
