### PR TITLE
feat: add Australian Payroll AU pay run, payslip and pay item reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you don't already have a Xero account and organisation already, can create on
 
 We recommend using a Demo Company to start with because it comes with some pre-loaded sample data. Once you are logged in, switch to it by using the top left-hand dropdown and selecting "Demo Company". You can reset the data on a Demo Company, or change the country, at any time by using the top left-hand dropdown and navigating to [My Xero](https://my.xero.com).
 
-NOTE: To use Payroll-specific queries, the region should be either NZ or UK.
+NOTE: Employee, leave and timesheet payroll tools currently target NZ or UK. Australian organisations can use the Payroll AU **read** tools `list-payroll-pay-runs`, `list-payroll-payslips`, `get-payroll-payslip` and `list-payroll-pay-items`. Those tools do not post, approve or delete pay runs.
 
 ### Authentication
 
@@ -59,6 +59,8 @@ Custom connections require different scopes depending on when they were created.
 > **Note:** The MCP server automatically tries V1 scopes first and falls back to V2 if needed.
 > 
 > You can override these by setting the `XERO_SCOPES` environment variable to a space-separated list of scopes.
+>
+> `list-payroll-pay-runs`, `list-payroll-payslips` and `get-payroll-payslip` also need `payroll.payruns` and `payroll.payslip`. Those scopes are not in the default V1/V2 lists, so existing Custom Connections keep working. Add them via `XERO_SCOPES` if you use the Australian pay-run tools. `list-payroll-pay-items` uses the default `payroll.settings` scope.
 
 ##### Integrating the MCP server with Claude Desktop
 
@@ -151,6 +153,10 @@ payroll.timesheets
 - `list-trial-balance`: Retrieve a trial balance report
 - `list-bank-transactions`: Retrieve a list of bank account transactions
 - `list-payroll-employees`: Retrieve a list of Payroll Employees
+- `list-payroll-pay-runs`: Retrieve Australian Payroll AU pay runs
+- `list-payroll-payslips`: Retrieve payslip summaries on an Australian pay run
+- `get-payroll-payslip`: Retrieve one Australian payslip, including superannuation lines
+- `list-payroll-pay-items`: Retrieve Australian earnings rates, deductions, leave and reimbursement types
 - `list-report-balance-sheet`: Retrieve a balance sheet report
 - `list-payroll-employee-leave`: Retrieve a Payroll Employee's leave records
 - `list-payroll-employee-leave-balances`: Retrieve a Payroll Employee's leave balances

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,13 +31,39 @@
         "vitest": "^4.1.5"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -600,6 +626,40 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
@@ -697,7 +757,6 @@
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -748,7 +807,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1092,7 +1150,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1593,7 +1650,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1837,7 +1893,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2284,7 +2339,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3187,7 +3241,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3816,7 +3869,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3890,7 +3942,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4159,7 +4210,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/handlers/__tests__/get-xero-payroll-au-payslip.handler.test.ts
+++ b/src/handlers/__tests__/get-xero-payroll-au-payslip.handler.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authenticate, getOrganisations, getPayslip } = vi.hoisted(() => ({
+  authenticate: vi.fn(),
+  getOrganisations: vi.fn(),
+  getPayslip: vi.fn(),
+}));
+
+vi.mock("../../clients/xero-client.js", () => ({
+  xeroClient: {
+    tenantId: "tenant-1",
+    authenticate,
+    accountingApi: { getOrganisations },
+    payrollAUApi: { getPayslip },
+  },
+}));
+
+import { resetPayrollRegionCache } from "../../helpers/get-payroll-region.js";
+import { getXeroPayrollAuPayslip } from "../get-xero-payroll-au-payslip.handler.js";
+
+describe("getXeroPayrollAuPayslip", () => {
+  beforeEach(() => {
+    resetPayrollRegionCache();
+    authenticate.mockReset().mockResolvedValue(undefined);
+    getOrganisations.mockReset();
+    getPayslip.mockReset();
+  });
+
+  it("returns earnings and superannuation lines for an Australian payslip", async () => {
+    getOrganisations.mockResolvedValue({
+      body: { organisations: [{ countryCode: "AU" }] },
+    });
+    getPayslip.mockResolvedValue({
+      body: {
+        payslip: {
+          payslipID: "ps-1",
+          employeeID: "au-1",
+          wages: 1000,
+          _super: 115,
+          earningsLines: [{ earningsRateID: "er-ord", amount: 1000 }],
+          superannuationLines: [
+            {
+              superMembershipID: "sm-1",
+              contributionType: "SGC",
+              amount: 115,
+            },
+          ],
+        },
+      },
+    });
+
+    const response = await getXeroPayrollAuPayslip("ps-1");
+
+    expect(response.isError).toBe(false);
+    if (response.isError) {
+      throw new Error(response.error);
+    }
+    expect(response.result?.superannuationLines).toEqual([
+      expect.objectContaining({
+        superMembershipID: "sm-1",
+        amount: 115,
+      }),
+    ]);
+  });
+
+  it("refuses NZ organisations", async () => {
+    getOrganisations.mockResolvedValue({
+      body: { organisations: [{ countryCode: "NZ" }] },
+    });
+
+    const response = await getXeroPayrollAuPayslip("ps-1");
+
+    expect(response.isError).toBe(true);
+    expect(getPayslip).not.toHaveBeenCalled();
+  });
+});

--- a/src/handlers/__tests__/list-xero-payroll-au-pay-items.handler.test.ts
+++ b/src/handlers/__tests__/list-xero-payroll-au-pay-items.handler.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authenticate, getOrganisations, getPayItems } = vi.hoisted(() => ({
+  authenticate: vi.fn(),
+  getOrganisations: vi.fn(),
+  getPayItems: vi.fn(),
+}));
+
+vi.mock("../../clients/xero-client.js", () => ({
+  xeroClient: {
+    tenantId: "tenant-1",
+    authenticate,
+    accountingApi: { getOrganisations },
+    payrollAUApi: { getPayItems },
+  },
+}));
+
+import { resetPayrollRegionCache } from "../../helpers/get-payroll-region.js";
+import { listXeroPayrollAuPayItems } from "../list-xero-payroll-au-pay-items.handler.js";
+
+describe("listXeroPayrollAuPayItems", () => {
+  beforeEach(() => {
+    resetPayrollRegionCache();
+    authenticate.mockReset().mockResolvedValue(undefined);
+    getOrganisations.mockReset();
+    getPayItems.mockReset();
+  });
+
+  it("returns earnings rates including super exemption flags", async () => {
+    getOrganisations.mockResolvedValue({
+      body: { organisations: [{ countryCode: "AU" }] },
+    });
+    getPayItems.mockResolvedValue({
+      body: {
+        payItems: {
+          earningsRates: [
+            {
+              earningsRateID: "er-ord",
+              name: "Ordinary Hours",
+              isExemptFromSuper: false,
+              isReportableAsW1: true,
+            },
+          ],
+          deductionTypes: [],
+          leaveTypes: [],
+          reimbursementTypes: [],
+        },
+      },
+    });
+
+    const response = await listXeroPayrollAuPayItems();
+
+    expect(response.isError).toBe(false);
+    if (response.isError) {
+      throw new Error(response.error);
+    }
+    expect(response.result?.earningsRates?.[0]).toEqual(
+      expect.objectContaining({
+        name: "Ordinary Hours",
+        isExemptFromSuper: false,
+        isReportableAsW1: true,
+      }),
+    );
+  });
+});

--- a/src/handlers/__tests__/list-xero-payroll-au-pay-runs.handler.test.ts
+++ b/src/handlers/__tests__/list-xero-payroll-au-pay-runs.handler.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authenticate, getOrganisations, getPayRuns } = vi.hoisted(() => ({
+  authenticate: vi.fn(),
+  getOrganisations: vi.fn(),
+  getPayRuns: vi.fn(),
+}));
+
+vi.mock("../../clients/xero-client.js", () => ({
+  xeroClient: {
+    tenantId: "tenant-1",
+    authenticate,
+    accountingApi: { getOrganisations },
+    payrollAUApi: { getPayRuns },
+  },
+}));
+
+import { resetPayrollRegionCache } from "../../helpers/get-payroll-region.js";
+import { listXeroPayrollAuPayRuns } from "../list-xero-payroll-au-pay-runs.handler.js";
+
+describe("listXeroPayrollAuPayRuns", () => {
+  beforeEach(() => {
+    resetPayrollRegionCache();
+    authenticate.mockReset().mockResolvedValue(undefined);
+    getOrganisations.mockReset();
+    getPayRuns.mockReset();
+  });
+
+  it("lists Payroll AU pay runs for Australian organisations", async () => {
+    getOrganisations.mockResolvedValue({
+      body: { organisations: [{ countryCode: "AU" }] },
+    });
+    getPayRuns.mockResolvedValue({
+      body: {
+        payRuns: [
+          {
+            payRunID: "pr-1",
+            payrollCalendarID: "cal-1",
+            wages: 1000,
+            tax: 200,
+            _super: 115,
+            netPay: 800,
+          },
+        ],
+      },
+    });
+
+    const response = await listXeroPayrollAuPayRuns();
+
+    expect(response.isError).toBe(false);
+    if (response.isError) {
+      throw new Error(response.error);
+    }
+    expect(getPayRuns).toHaveBeenCalledOnce();
+    expect(response.result?.[0]?.payRunID).toBe("pr-1");
+    expect(response.result?.[0]?._super).toBe(115);
+  });
+
+  it("refuses NZ organisations", async () => {
+    getOrganisations.mockResolvedValue({
+      body: { organisations: [{ countryCode: "NZ" }] },
+    });
+
+    const response = await listXeroPayrollAuPayRuns();
+
+    expect(response.isError).toBe(true);
+    if (!response.isError) {
+      throw new Error("expected NZ organisations to be rejected");
+    }
+    expect(response.error).toMatch(/Australian organisations/i);
+    expect(getPayRuns).not.toHaveBeenCalled();
+  });
+});

--- a/src/handlers/__tests__/list-xero-payroll-au-pay-runs.handler.test.ts
+++ b/src/handlers/__tests__/list-xero-payroll-au-pay-runs.handler.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../clients/xero-client.js", () => ({
 
 import { resetPayrollRegionCache } from "../../helpers/get-payroll-region.js";
 import { listXeroPayrollAuPayRuns } from "../list-xero-payroll-au-pay-runs.handler.js";
+import ListPayrollPayRunsTool from "../../tools/list/list-payroll-pay-runs.tool.js";
 
 describe("listXeroPayrollAuPayRuns", () => {
   beforeEach(() => {
@@ -69,5 +70,34 @@ describe("listXeroPayrollAuPayRuns", () => {
     }
     expect(response.error).toMatch(/Australian organisations/i);
     expect(getPayRuns).not.toHaveBeenCalled();
+  });
+
+  it("retrieves the requested page of pay runs", async () => {
+    getOrganisations.mockResolvedValue({
+      body: { organisations: [{ countryCode: "AU" }] },
+    });
+    getPayRuns.mockImplementation(async (...args: unknown[]) => ({
+      body: { payRuns: [{ payRunID: args[4] === 2 ? "page-two" : "page-one" }] },
+    }));
+
+    const response = await listXeroPayrollAuPayRuns(2);
+
+    expect(response.result?.[0]?.payRunID).toBe("page-two");
+  });
+
+  it("exposes paging and identifies a full page in the tool response", async () => {
+    getOrganisations.mockResolvedValue({
+      body: { organisations: [{ countryCode: "AU" }] },
+    });
+    getPayRuns.mockResolvedValue({
+      body: { payRuns: Array.from({ length: 100 }, (_, index) => ({ payRunID: `pr-${index}` })) },
+    });
+    const tool = ListPayrollPayRunsTool();
+    const result = await tool.handler({ page: 2 }, {} as never);
+
+    expect(getPayRuns.mock.calls[0][4]).toBe(2);
+    expect(result.content).toEqual(expect.arrayContaining([
+      { type: "text", text: "Found 100 pay runs on page 2. Request page 3 for more results." },
+    ]));
   });
 });

--- a/src/handlers/__tests__/list-xero-payroll-au-payslips.handler.test.ts
+++ b/src/handlers/__tests__/list-xero-payroll-au-payslips.handler.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authenticate, getOrganisations, getPayRun } = vi.hoisted(() => ({
+  authenticate: vi.fn(),
+  getOrganisations: vi.fn(),
+  getPayRun: vi.fn(),
+}));
+
+vi.mock("../../clients/xero-client.js", () => ({
+  xeroClient: {
+    tenantId: "tenant-1",
+    authenticate,
+    accountingApi: { getOrganisations },
+    payrollAUApi: { getPayRun },
+  },
+}));
+
+import { resetPayrollRegionCache } from "../../helpers/get-payroll-region.js";
+import { listXeroPayrollAuPayslips } from "../list-xero-payroll-au-payslips.handler.js";
+
+describe("listXeroPayrollAuPayslips", () => {
+  beforeEach(() => {
+    resetPayrollRegionCache();
+    authenticate.mockReset().mockResolvedValue(undefined);
+    getOrganisations.mockReset();
+    getPayRun.mockReset();
+  });
+
+  it("returns payslip summaries from the Payroll AU pay run, including super", async () => {
+    getOrganisations.mockResolvedValue({
+      body: { organisations: [{ countryCode: "AU" }] },
+    });
+    getPayRun.mockResolvedValue({
+      body: {
+        payRuns: [
+          {
+            payRunID: "pr-1",
+            payslips: [
+              {
+                payslipID: "ps-1",
+                employeeID: "au-1",
+                firstName: "Alex",
+                lastName: "Ng",
+                wages: 1000,
+                tax: 200,
+                _super: 115,
+                netPay: 800,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const response = await listXeroPayrollAuPayslips("pr-1");
+
+    expect(response.isError).toBe(false);
+    if (response.isError) {
+      throw new Error(response.error);
+    }
+    expect(getPayRun).toHaveBeenCalledWith(
+      "tenant-1",
+      "pr-1",
+      expect.anything(),
+    );
+    expect(response.result).toEqual([
+      expect.objectContaining({
+        payslipID: "ps-1",
+        _super: 115,
+        netPay: 800,
+      }),
+    ]);
+  });
+});

--- a/src/handlers/get-xero-payroll-au-payslip.handler.ts
+++ b/src/handlers/get-xero-payroll-au-payslip.handler.ts
@@ -1,0 +1,36 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { assertAustralianPayroll } from "../helpers/get-payroll-region.js";
+import { AuPayslip } from "../types/payroll-au-types.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function getPayslip(payslipID: string): Promise<AuPayslip | null> {
+  await assertAustralianPayroll("get-payroll-payslip");
+
+  const response = await xeroClient.payrollAUApi.getPayslip(
+    xeroClient.tenantId,
+    payslipID,
+    getClientHeaders(),
+  );
+  return response.body.payslip ?? null;
+}
+
+export async function getXeroPayrollAuPayslip(
+  payslipID: string,
+): Promise<XeroClientResponse<AuPayslip | null>> {
+  try {
+    const payslip = await getPayslip(payslipID);
+    return {
+      result: payslip,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-payroll-au-pay-items.handler.ts
+++ b/src/handlers/list-xero-payroll-au-pay-items.handler.ts
@@ -1,0 +1,39 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { assertAustralianPayroll } from "../helpers/get-payroll-region.js";
+import { AuPayItem } from "../types/payroll-au-types.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function getPayItems(): Promise<AuPayItem | null> {
+  await assertAustralianPayroll("list-payroll-pay-items");
+
+  const response = await xeroClient.payrollAUApi.getPayItems(
+    xeroClient.tenantId,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    getClientHeaders(),
+  );
+  return response.body.payItems ?? null;
+}
+
+export async function listXeroPayrollAuPayItems(): Promise<
+  XeroClientResponse<AuPayItem | null>
+> {
+  try {
+    const payItems = await getPayItems();
+    return {
+      result: payItems,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-payroll-au-pay-runs.handler.ts
+++ b/src/handlers/list-xero-payroll-au-pay-runs.handler.ts
@@ -1,0 +1,40 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { assertAustralianPayroll } from "../helpers/get-payroll-region.js";
+import { AuPayRun } from "../types/payroll-au-types.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function getPayRuns(): Promise<AuPayRun[]> {
+  await assertAustralianPayroll("list-payroll-pay-runs");
+
+  const payRuns = await xeroClient.payrollAUApi.getPayRuns(
+    xeroClient.tenantId,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    getClientHeaders(),
+  );
+
+  return payRuns.body.payRuns ?? [];
+}
+
+export async function listXeroPayrollAuPayRuns(): Promise<
+  XeroClientResponse<AuPayRun[]>
+> {
+  try {
+    const payRuns = await getPayRuns();
+    return {
+      result: payRuns,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/list-xero-payroll-au-pay-runs.handler.ts
+++ b/src/handlers/list-xero-payroll-au-pay-runs.handler.ts
@@ -5,7 +5,7 @@ import { assertAustralianPayroll } from "../helpers/get-payroll-region.js";
 import { AuPayRun } from "../types/payroll-au-types.js";
 import { XeroClientResponse } from "../types/tool-response.js";
 
-async function getPayRuns(): Promise<AuPayRun[]> {
+async function getPayRuns(page: number): Promise<AuPayRun[]> {
   await assertAustralianPayroll("list-payroll-pay-runs");
 
   const payRuns = await xeroClient.payrollAUApi.getPayRuns(
@@ -13,18 +13,18 @@ async function getPayRuns(): Promise<AuPayRun[]> {
     undefined,
     undefined,
     undefined,
-    undefined,
+    page,
     getClientHeaders(),
   );
 
   return payRuns.body.payRuns ?? [];
 }
 
-export async function listXeroPayrollAuPayRuns(): Promise<
+export async function listXeroPayrollAuPayRuns(page = 1): Promise<
   XeroClientResponse<AuPayRun[]>
 > {
   try {
-    const payRuns = await getPayRuns();
+    const payRuns = await getPayRuns(page);
     return {
       result: payRuns,
       isError: false,

--- a/src/handlers/list-xero-payroll-au-payslips.handler.ts
+++ b/src/handlers/list-xero-payroll-au-payslips.handler.ts
@@ -1,0 +1,37 @@
+import { xeroClient } from "../clients/xero-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { getClientHeaders } from "../helpers/get-client-headers.js";
+import { assertAustralianPayroll } from "../helpers/get-payroll-region.js";
+import { AuPayslipSummary } from "../types/payroll-au-types.js";
+import { XeroClientResponse } from "../types/tool-response.js";
+
+async function getPayslips(payRunID: string): Promise<AuPayslipSummary[]> {
+  await assertAustralianPayroll("list-payroll-payslips");
+
+  const payRuns = await xeroClient.payrollAUApi.getPayRun(
+    xeroClient.tenantId,
+    payRunID,
+    getClientHeaders(),
+  );
+  const payRun = payRuns.body.payRuns?.[0];
+  return payRun?.payslips ?? [];
+}
+
+export async function listXeroPayrollAuPayslips(
+  payRunID: string,
+): Promise<XeroClientResponse<AuPayslipSummary[]>> {
+  try {
+    const payslips = await getPayslips(payRunID);
+    return {
+      result: payslips,
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/helpers/__tests__/get-payroll-region.test.ts
+++ b/src/helpers/__tests__/get-payroll-region.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { CountryCode } from "xero-node";
+
+import { toPayrollRegion } from "../get-payroll-region.js";
+
+describe("toPayrollRegion", () => {
+  it("maps AU from string and enum", () => {
+    expect(toPayrollRegion("AU")).toBe("AU");
+    expect(toPayrollRegion(CountryCode.AU)).toBe("AU");
+  });
+
+  it("maps NZ and GB", () => {
+    expect(toPayrollRegion("NZ")).toBe("NZ");
+    expect(toPayrollRegion(CountryCode.NZ)).toBe("NZ");
+    expect(toPayrollRegion("GB")).toBe("UK");
+    expect(toPayrollRegion(CountryCode.GB)).toBe("UK");
+  });
+
+  it("returns OTHER for missing or unknown codes", () => {
+    expect(toPayrollRegion(undefined)).toBe("OTHER");
+    expect(toPayrollRegion("US")).toBe("OTHER");
+  });
+});

--- a/src/helpers/__tests__/setup-env.ts
+++ b/src/helpers/__tests__/setup-env.ts
@@ -1,0 +1,2 @@
+process.env.XERO_CLIENT_ID ??= "test-client-id";
+process.env.XERO_CLIENT_SECRET ??= "test-client-secret";

--- a/src/helpers/get-payroll-region.ts
+++ b/src/helpers/get-payroll-region.ts
@@ -1,0 +1,53 @@
+import { CountryCode } from "xero-node";
+
+import { xeroClient } from "../clients/xero-client.js";
+import { getClientHeaders } from "./get-client-headers.js";
+
+export type PayrollRegion = "AU" | "NZ" | "UK" | "OTHER";
+
+const cache = new Map<string, PayrollRegion>();
+
+export function resetPayrollRegionCache(): void {
+  cache.clear();
+}
+
+export function toPayrollRegion(code: unknown): PayrollRegion {
+  const value = String(code ?? "");
+  if (value === "AU" || code === CountryCode.AU) {
+    return "AU";
+  }
+  if (value === "NZ" || code === CountryCode.NZ) {
+    return "NZ";
+  }
+  if (value === "GB" || value === "UK" || code === CountryCode.GB) {
+    return "UK";
+  }
+  return "OTHER";
+}
+
+export async function getPayrollRegion(): Promise<PayrollRegion> {
+  await xeroClient.authenticate();
+  const tenantId = xeroClient.tenantId || "";
+  const cached = cache.get(tenantId);
+  if (cached) {
+    return cached;
+  }
+
+  const response = await xeroClient.accountingApi.getOrganisations(
+    tenantId,
+    getClientHeaders(),
+  );
+  const code = response.body.organisations?.[0]?.countryCode;
+  const region = toPayrollRegion(code);
+  cache.set(tenantId, region);
+  return region;
+}
+
+export async function assertAustralianPayroll(toolName: string): Promise<void> {
+  const region = await getPayrollRegion();
+  if (region !== "AU") {
+    throw new Error(
+      `${toolName} reads Xero Payroll AU. It is only available for Australian organisations.`,
+    );
+  }
+}

--- a/src/tools/get/get-payroll-payslip.tool.ts
+++ b/src/tools/get/get-payroll-payslip.tool.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+import { getXeroPayrollAuPayslip } from "../../handlers/get-xero-payroll-au-payslip.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const GetPayrollPayslipTool = CreateXeroTool(
+  "get-payroll-payslip",
+  `Retrieve one Australian Payroll AU payslip by ID, including earnings lines and superannuation lines (membership, contribution type, amount, payment date). Australian organisations only. Requires payroll.payslip scope. Read-only — does not post or approve pay runs.`,
+  {
+    payslipID: z.string().describe("The Payroll AU payslip ID to retrieve."),
+  },
+  async ({ payslipID }: { payslipID: string }) => {
+    const response = await getXeroPayrollAuPayslip(payslipID);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error retrieving payslip: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const payslip = response.result;
+
+    if (!payslip) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `No payslip found with ID: ${payslipID}`,
+          },
+        ],
+      };
+    }
+
+    const superLines =
+      payslip.superannuationLines
+        ?.map((line) =>
+          [
+            `  Super membership: ${line.superMembershipID ?? "unknown"}`,
+            line.contributionType
+              ? `  Contribution type: ${String(line.contributionType)}`
+              : null,
+            line.percentage !== undefined
+              ? `  Percentage: ${line.percentage}`
+              : null,
+            line.amount !== undefined ? `  Amount: ${line.amount}` : null,
+            line.paymentDateForThisPeriod
+              ? `  Payment date: ${line.paymentDateForThisPeriod}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        )
+        .join("\n") || "  None";
+
+    const earningsLines =
+      payslip.earningsLines
+        ?.map((line) =>
+          [
+            `  Earnings rate: ${line.earningsRateID}`,
+            line.amount !== undefined ? `  Amount: ${line.amount}` : null,
+            line.numberOfUnits !== undefined
+              ? `  Units: ${line.numberOfUnits}`
+              : null,
+            line.ratePerUnit !== undefined
+              ? `  Rate per unit: ${line.ratePerUnit}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        )
+        .join("\n") || "  None";
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            `Payslip ID: ${payslip.payslipID}`,
+            `Employee ID: ${payslip.employeeID}`,
+            [payslip.firstName, payslip.lastName].filter(Boolean).join(" ")
+              ? `Name: ${[payslip.firstName, payslip.lastName].filter(Boolean).join(" ")}`
+              : null,
+            payslip.wages !== undefined ? `Wages: ${payslip.wages}` : null,
+            payslip.tax !== undefined ? `Tax: ${payslip.tax}` : null,
+            payslip._super !== undefined ? `Super: ${payslip._super}` : null,
+            payslip.netPay !== undefined ? `Net Pay: ${payslip.netPay}` : null,
+            "Earnings lines:",
+            earningsLines,
+            "Superannuation lines:",
+            superLines,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default GetPayrollPayslipTool;

--- a/src/tools/get/index.ts
+++ b/src/tools/get/index.ts
@@ -1,5 +1,7 @@
+import GetPayrollPayslipTool from "./get-payroll-payslip.tool.js";
 import GetPayrollTimesheetTool from "./get-payroll-timesheet.tool.js";
 
 export const GetTools = [
   GetPayrollTimesheetTool,
+  GetPayrollPayslipTool,
 ];

--- a/src/tools/list/index.ts
+++ b/src/tools/list/index.ts
@@ -20,6 +20,9 @@ import ListPayrollEmployeesTool from "./list-payroll-employees.tool.js";
 import ListPayrollLeavePeriodsToolTool
   from "./list-payroll-leave-periods.tool.js";
 import ListPayrollLeaveTypesTool from "./list-payroll-leave-types.tool.js";
+import ListPayrollPayItemsTool from "./list-payroll-pay-items.tool.js";
+import ListPayrollPayRunsTool from "./list-payroll-pay-runs.tool.js";
+import ListPayrollPayslipsTool from "./list-payroll-payslips.tool.js";
 import ListPayrollTimesheetsTool from "./list-payroll-timesheets.tool.js";
 import ListProfitAndLossTool from "./list-profit-and-loss.tool.js";
 import ListQuotesTool from "./list-quotes.tool.js";
@@ -53,6 +56,9 @@ export const ListTools = [
   ListAgedReceivablesByContact,
   ListAgedPayablesByContact,
   ListPayrollTimesheetsTool,
+  ListPayrollPayRunsTool,
+  ListPayrollPayslipsTool,
+  ListPayrollPayItemsTool,
   ListContactGroupsTool,
   ListTrackingCategoriesTool
 ];

--- a/src/tools/list/list-payroll-pay-items.tool.ts
+++ b/src/tools/list/list-payroll-pay-items.tool.ts
@@ -1,0 +1,91 @@
+import { listXeroPayrollAuPayItems } from "../../handlers/list-xero-payroll-au-pay-items.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+
+const ListPayrollPayItemsTool = CreateXeroTool(
+  "list-payroll-pay-items",
+  `List Australian Payroll AU pay items: earnings rates, deduction types, leave types and reimbursement types. Use this to map ordinary earnings versus allowances and to see which rates are exempt from super. Australian organisations only. Requires payroll.settings scope.`,
+  {},
+  async () => {
+    const response = await listXeroPayrollAuPayItems();
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing pay items: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const payItems = response.result;
+
+    if (!payItems) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "No pay items found.",
+          },
+        ],
+      };
+    }
+
+    const earnings =
+      payItems.earningsRates
+        ?.map((rate) =>
+          [
+            `  ${rate.name ?? rate.earningsRateID}`,
+            rate.earningsType ? `type=${String(rate.earningsType)}` : null,
+            rate.isExemptFromSuper !== undefined
+              ? `exemptFromSuper=${rate.isExemptFromSuper}`
+              : null,
+            rate.isExemptFromTax !== undefined
+              ? `exemptFromTax=${rate.isExemptFromTax}`
+              : null,
+            rate.isReportableAsW1 !== undefined
+              ? `reportableAsW1=${rate.isReportableAsW1}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join(" "),
+        )
+        .join("\n") || "  None";
+
+    const deductions =
+      payItems.deductionTypes
+        ?.map((item) => `  ${item.name ?? item.deductionTypeID}`)
+        .join("\n") || "  None";
+
+    const leave =
+      payItems.leaveTypes
+        ?.map((item) => `  ${item.name ?? item.leaveTypeID}`)
+        .join("\n") || "  None";
+
+    const reimbursements =
+      payItems.reimbursementTypes
+        ?.map((item) => `  ${item.name ?? item.reimbursementTypeID}`)
+        .join("\n") || "  None";
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            "Earnings rates:",
+            earnings,
+            "Deduction types:",
+            deductions,
+            "Leave types:",
+            leave,
+            "Reimbursement types:",
+            reimbursements,
+          ].join("\n"),
+        },
+      ],
+    };
+  },
+);
+
+export default ListPayrollPayItemsTool;

--- a/src/tools/list/list-payroll-pay-runs.tool.ts
+++ b/src/tools/list/list-payroll-pay-runs.tool.ts
@@ -1,0 +1,60 @@
+import { listXeroPayrollAuPayRuns } from "../../handlers/list-xero-payroll-au-pay-runs.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { AuPayRun } from "../../types/payroll-au-types.js";
+
+const ListPayrollPayRunsTool = CreateXeroTool(
+  "list-payroll-pay-runs",
+  `List Australian Payroll AU pay runs.
+Includes period dates, payment date, status, and wage/tax/super totals. Use list-payroll-payslips with a payRunID to see employees on a run. Australian organisations only. Requires payroll.payruns (or equivalent) scope.`,
+  {},
+  async () => {
+    const response = await listXeroPayrollAuPayRuns();
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing pay runs: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const payRuns = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${payRuns?.length || 0} pay runs:`,
+        },
+        ...(payRuns?.map((payRun: AuPayRun) => ({
+          type: "text" as const,
+          text: [
+            `Pay Run ID: ${payRun.payRunID}`,
+            `Payroll Calendar ID: ${payRun.payrollCalendarID}`,
+            payRun.payRunPeriodStartDate
+              ? `Period Start: ${payRun.payRunPeriodStartDate}`
+              : null,
+            payRun.payRunPeriodEndDate
+              ? `Period End: ${payRun.payRunPeriodEndDate}`
+              : null,
+            payRun.paymentDate ? `Payment Date: ${payRun.paymentDate}` : null,
+            payRun.payRunStatus
+              ? `Status: ${String(payRun.payRunStatus)}`
+              : null,
+            payRun.wages !== undefined ? `Wages: ${payRun.wages}` : null,
+            payRun.tax !== undefined ? `Tax: ${payRun.tax}` : null,
+            payRun._super !== undefined ? `Super: ${payRun._super}` : null,
+            payRun.netPay !== undefined ? `Net Pay: ${payRun.netPay}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPayrollPayRunsTool;

--- a/src/tools/list/list-payroll-pay-runs.tool.ts
+++ b/src/tools/list/list-payroll-pay-runs.tool.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { listXeroPayrollAuPayRuns } from "../../handlers/list-xero-payroll-au-pay-runs.handler.js";
 import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
 import { AuPayRun } from "../../types/payroll-au-types.js";
@@ -6,9 +7,12 @@ const ListPayrollPayRunsTool = CreateXeroTool(
   "list-payroll-pay-runs",
   `List Australian Payroll AU pay runs.
 Includes period dates, payment date, status, and wage/tax/super totals. Use list-payroll-payslips with a payRunID to see employees on a run. Australian organisations only. Requires payroll.payruns (or equivalent) scope.`,
-  {},
-  async () => {
-    const response = await listXeroPayrollAuPayRuns();
+  {
+    page: z.number().int().min(1).default(1)
+      .describe("Page number, with up to 100 pay runs per page"),
+  },
+  async ({ page }) => {
+    const response = await listXeroPayrollAuPayRuns(page);
 
     if (response.isError) {
       return {
@@ -27,7 +31,7 @@ Includes period dates, payment date, status, and wage/tax/super totals. Use list
       content: [
         {
           type: "text" as const,
-          text: `Found ${payRuns?.length || 0} pay runs:`,
+          text: `Found ${payRuns?.length || 0} pay runs on page ${page}.${payRuns?.length === 100 ? ` Request page ${page + 1} for more results.` : ""}`,
         },
         ...(payRuns?.map((payRun: AuPayRun) => ({
           type: "text" as const,

--- a/src/tools/list/list-payroll-payslips.tool.ts
+++ b/src/tools/list/list-payroll-payslips.tool.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+import { listXeroPayrollAuPayslips } from "../../handlers/list-xero-payroll-au-payslips.handler.js";
+import { CreateXeroTool } from "../../helpers/create-xero-tool.js";
+import { AuPayslipSummary } from "../../types/payroll-au-types.js";
+
+const ListPayrollPayslipsTool = CreateXeroTool(
+  "list-payroll-payslips",
+  `List payslip summaries on an Australian Payroll AU pay run.
+Shows wages, tax, super and net pay per employee. Use get-payroll-payslip for earnings and superannuation lines. Australian organisations only. Requires payroll.payruns and payroll.payslip scopes.`,
+  {
+    payRunID: z
+      .string()
+      .describe("The Payroll AU pay run ID whose payslips should be listed."),
+  },
+  async ({ payRunID }: { payRunID: string }) => {
+    const response = await listXeroPayrollAuPayslips(payRunID);
+
+    if (response.isError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing payslips: ${response.error}`,
+          },
+        ],
+      };
+    }
+
+    const payslips = response.result;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Found ${payslips?.length || 0} payslips on pay run ${payRunID}:`,
+        },
+        ...(payslips?.map((payslip: AuPayslipSummary) => ({
+          type: "text" as const,
+          text: [
+            `Payslip ID: ${payslip.payslipID}`,
+            `Employee ID: ${payslip.employeeID}`,
+            [payslip.firstName, payslip.lastName].filter(Boolean).join(" ")
+              ? `Name: ${[payslip.firstName, payslip.lastName].filter(Boolean).join(" ")}`
+              : null,
+            payslip.wages !== undefined ? `Wages: ${payslip.wages}` : null,
+            payslip.tax !== undefined ? `Tax: ${payslip.tax}` : null,
+            payslip._super !== undefined ? `Super: ${payslip._super}` : null,
+            payslip.netPay !== undefined ? `Net Pay: ${payslip.netPay}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })) || []),
+      ],
+    };
+  },
+);
+
+export default ListPayrollPayslipsTool;

--- a/src/types/payroll-au-types.ts
+++ b/src/types/payroll-au-types.ts
@@ -1,3 +1,7 @@
 export { Timesheet as AuTimesheet } from "xero-node/dist/gen/model/payroll-au/timesheet.js";
 export { TimesheetLine as AuTimesheetLine } from "xero-node/dist/gen/model/payroll-au/timesheetLine.js";
 export { TimesheetStatus } from "xero-node/dist/gen/model/payroll-au/timesheetStatus.js";
+export { PayRun as AuPayRun } from "xero-node/dist/gen/model/payroll-au/payRun.js";
+export { Payslip as AuPayslip } from "xero-node/dist/gen/model/payroll-au/payslip.js";
+export { PayslipSummary as AuPayslipSummary } from "xero-node/dist/gen/model/payroll-au/payslipSummary.js";
+export { PayItem as AuPayItem } from "xero-node/dist/gen/model/payroll-au/payItem.js";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    setupFiles: ["src/helpers/__tests__/setup-env.ts"],
   },
 });


### PR DESCRIPTION
Adds read-only Payroll AU tools for pay runs, payslip summaries, payslip details and pay items. Organisation-country checks reject non-Australian tenants. Payslip output includes earnings and superannuation lines.

`list-payroll-pay-runs` accepts a positive integer `page`, defaulting to 1. It forwards that page to Xero, identifies the returned page and prompts for the next page when 100 results are returned. It no longer leaves callers unable to retrieve later pay runs.

Existing default scopes are unchanged. Pay items use `payroll.settings`; pay runs and payslips need `payroll.payruns` and `payroll.payslip` through `XERO_SCOPES`, as documented in the README. Timesheet and leave routing remain outside this PR's scope. Related to #130.

Verification, 10 September 2026:

- `npm test`: 25 tests passed, including retrieval of page 2 and the tool's continuation message.
- `npm run lint` and `npm run build` passed.
- `npm ci --ignore-scripts` passed after repairing missing optional test-tool dependency entries in `package-lock.json`. Direct dependencies are unchanged.

No hosted checks are currently reported on this PR. Payroll API responses were mocked; no live Demo Company request was made.
