### PR TITLE
fix: stop ensureError leaking bearer tokens into tool responses

### DIFF
--- a/src/helpers/__tests__/ensure-error.test.ts
+++ b/src/helpers/__tests__/ensure-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { ensureError } from "../ensure-error.js";
+
+const BEARER = "Bearer eyJhbGciOiJSUzI1NiJ9.super-secret-access-token";
+
+describe("ensureError", () => {
+  it("does not leak credentials from a rejected xero-node SDK object", () => {
+    const sdkRejection = {
+      response: {
+        statusCode: 400,
+        body: { problem: { title: "Bad Request", detail: "Name is required" } },
+      },
+      request: {
+        headers: {
+          authorization: BEARER,
+          "xero-tenant-id": "1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5a6b",
+        },
+      },
+    };
+
+    const message = ensureError(sdkRejection).message;
+
+    expect(message).not.toContain(BEARER);
+    expect(message).not.toContain("authorization");
+    expect(message).toContain("Bad Request");
+  });
+
+  it("does not leak credentials from an arbitrary thrown object", () => {
+    const message = ensureError({
+      headers: { authorization: BEARER },
+    }).message;
+
+    expect(message).not.toContain(BEARER);
+  });
+
+  it("returns an existing Error unchanged", () => {
+    const original = new Error("boom");
+    expect(ensureError(original)).toBe(original);
+  });
+
+  it("still returns an Error for primitive throws", () => {
+    expect(ensureError("plain string")).toBeInstanceOf(Error);
+  });
+});

--- a/src/helpers/ensure-error.ts
+++ b/src/helpers/ensure-error.ts
@@ -1,13 +1,16 @@
+import { formatError } from "./format-error.js";
+
+/**
+ * Coerce an unknown thrown value into an Error.
+ *
+ * The message is built by `formatError`, which whitelists the fields it
+ * extracts. Never stringify the raw value here: the xero-node SDK rejects
+ * with a plain object whose `request.headers.authorization` field contains
+ * the caller's Bearer token, and every caller puts `err.message` straight
+ * into a tool response returned to the model.
+ */
 export function ensureError(value: unknown): Error {
   if (value instanceof Error) return value;
 
-  let stringified = "[Unable to stringify the thrown value]";
-  try {
-    stringified = JSON.stringify(value);
-  } catch {
-    /* empty */
-  }
-
-  const error = new Error(`Error thrown: ${stringified}`);
-  return error;
+  return new Error(formatError(value));
 }


### PR DESCRIPTION
## Problem

`ensureError` wraps any non-`Error` thrown value by calling `JSON.stringify` on
it and placing the result in the new error's message. xero-node 13.3.0 (the
version pinned in `package-lock.json`) rejects failed requests with
`JSON.stringify(new ApiError(err).generateError())`, and `ApiError` copies the
raw outbound request headers, including the caller's Bearer token, into
`response.request.headers`. All of the tool handlers put `err.message` directly
into the text returned to the model, so a failed Xero call could surface the
access token in a transcript. The SDK's non-throwing path rejects with the
equivalent plain object, which leaks the same way.

#173 closed the same hole in `formatError`, which already whitelists the fields
it extracts and documents this hazard. `ensureError` still serialises the raw
value.

## Fix

`ensureError` now delegates its message to `formatError` instead of
stringifying the thrown value, so a non-`Error` rejection produces the same
redacted message the SDK-error path already produces.

## Tests

Adds regression coverage in `src/helpers/__tests__/ensure-error.test.ts`
asserting the token is absent from the resulting message for the xero-node 13
JSON string rejection, the equivalent plain object, and an arbitrary object.
All three cases fail against the previous implementation and pass with this
change.

Verified on this branch rebased onto current `main` (f24583c): the three
credential cases fail against the unchanged `ensureError` and pass with the
fix; the full `vitest` suite passes (19 tests) and `npm run lint` is clean.

## Notes

No tool behaviour changes for callers that throw `Error` instances. A primitive
string throw now yields the generic message rather than the string itself,
which is the point: on 13.3.0 that string is the SDK error carrying the
headers. No new dependencies.

xero-node 20.0.0 (XeroAPI/xero-node#823) redacts these headers at the SDK
level, but this repo pins `^13.3.0`, so the server-side fix is still needed
until the SDK is bumped.
